### PR TITLE
fix: canonical URL preventing Google indexing

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,15 @@
+import { Metadata } from 'next';
 import Link from 'next/link';
+
+const siteUrl = process.env.SITE_URL || 'https://kt-tech.blog';
+
+export const metadata: Metadata = {
+  title: 'About',
+  description: 'フルスタックエンジニア Koki のプロフィール。React, Next.js, TypeScript, AWS, Python などの技術スタックと経歴。',
+  alternates: {
+    canonical: `${siteUrl}/about`,
+  },
+};
 import { BreadcrumbNav } from '@/components/Breadcrumb/BreadcrumbNav';
 import { Github } from 'lucide-react';
 import {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,7 +74,6 @@ export const metadata: Metadata = {
     google: 'IpGviaJMSPR7SL1E-maff_nCUNmuWWBXYRTLcDHZUcw',
   },
   alternates: {
-    canonical: url,
     types: {
       'application/rss+xml': `${url}/feed.xml`,
     },


### PR DESCRIPTION
## Summary
**重大なSEO修正**: root layoutの `canonical: "https://kt-tech.blog"` が全ページに継承され、Google がすべてのページをトップページの重複とみなしインデックスしない原因になっていた。

### 修正内容
- root layout から `canonical` を削除（RSSリンクは維持）
- About ページに個別の canonical + metadata 追加
- トップページ・記事詳細・ページネーションは既に正しい canonical を持っている

### 影響範囲
デプロイ後、Google Search Console で「URL検査」→「インデックス登録をリクエスト」を主要ページで実行すると、再クロール・再インデックスが早まります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)