### PR TITLE
feat: add SEO metadata to category, tag, and archive pages

### DIFF
--- a/src/app/archives/[archive]/page.tsx
+++ b/src/app/archives/[archive]/page.tsx
@@ -3,7 +3,38 @@ import { notFound } from 'next/navigation';
 import { getList } from '../../../../libs/notion';
 import Index from '@/components/Index/Index';
 import Title from '@/components/Title/Title';
+import { Metadata } from 'next';
 
+const siteUrl = process.env.SITE_URL || 'https://kt-tech.blog';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ archive: string }>;
+}): Promise<Metadata> {
+  const { archive } = await params;
+  const [year, month] = archive.split('-');
+  const title = `${year}年${parseInt(month)}月のアーカイブ`;
+  const description = `${year}年${parseInt(month)}月に公開された技術記事の一覧です。`;
+  const url = `${siteUrl}/archives/${archive}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
 
 export const runtime = 'edge';
 export default async function StaticDetailPage({

--- a/src/app/categories/[categoryId]/page/[pageId]/page.tsx
+++ b/src/app/categories/[categoryId]/page/[pageId]/page.tsx
@@ -4,9 +4,40 @@ import { getList, getCategoryList, getCategoryDetail } from '../../../../../../l
 import Paginate from '@/components/Pagination/Paginate';
 import Index from '@/components/Index/Index';
 import Title from '@/components/Title/Title';
+import { Metadata } from 'next';
 
 const ITEMS_PER_PAGE = 6;
+const siteUrl = process.env.SITE_URL || 'https://kt-tech.blog';
 
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ categoryId: string; pageId: string }>;
+}): Promise<Metadata> {
+  const { categoryId, pageId } = await params;
+  const category = await getCategoryDetail(decodeURIComponent(categoryId)).catch(() => null);
+  const name = category?.name || decodeURIComponent(categoryId);
+  const title = `${name}の記事一覧${Number(pageId) > 1 ? ` (${pageId}ページ目)` : ''}`;
+  const description = `${name}に関する技術記事の一覧です。`;
+  const url = `${siteUrl}/categories/${categoryId}/page/${pageId}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
 
 export const runtime = 'edge';
 export default async function StaticPaginationPage({

--- a/src/app/tags/[tagId]/page.tsx
+++ b/src/app/tags/[tagId]/page.tsx
@@ -5,7 +5,39 @@ import Sidebar from '@/components/SIdebar/Sidebar';
 import Index from '@/components/Index/Index';
 import Title from '@/components/Title/Title';
 import Link from 'next/link';
+import { Metadata } from 'next';
 
+const siteUrl = process.env.SITE_URL || 'https://kt-tech.blog';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ tagId: string }>;
+}): Promise<Metadata> {
+  const { tagId } = await params;
+  const tag = await getTagDetail(decodeURIComponent(tagId)).catch(() => null);
+  const name = tag?.name || decodeURIComponent(tagId);
+  const title = `${name}の記事一覧`;
+  const description = `${name}タグが付けられた技術記事の一覧です。`;
+  const url = `${siteUrl}/tags/${tagId}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
 
 export const runtime = 'edge';
 export default async function StaticDetailPage({


### PR DESCRIPTION
## Summary
- Add `generateMetadata()` to category, tag, and archive pages that were missing title, description, canonical URL, OpenGraph, and Twitter Card metadata
- This improves search engine discoverability for these listing pages which previously inherited only default metadata

## Additional changes (Notion-side, not in this PR)
- Set Slug property on 18 articles that were using Notion page IDs as URLs (causing "Detected - not indexed" in Search Console)
- Updated session-to-notion skill to require Slug on new articles

## Test plan
- [ ] Verify build passes
- [ ] Check category page (`/categories/xxx/page/1`) has correct meta tags
- [ ] Check tag page (`/tags/xxx`) has correct meta tags
- [ ] Check archive page (`/archives/2026-03`) has correct meta tags
- [ ] After deploy, verify sitemap URLs use slugs instead of Notion page IDs
- [ ] Resubmit sitemap in Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)