### PR TITLE
fix: Home と Blog一覧を Edge Runtime にして新記事を即時反映する

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,15 @@ const nextConfig = {
   async headers() {
     return [
       {
+        // トップページは新着記事の鮮度を優先して s-maxage を短くする。
+        // Cloudflare Pages では ISR が使えないため、Edge Runtime + このヘッダで
+        // 「5分ごとに裏で作り直す」ISR相当の挙動にしている。
+        source: '/',
+        headers: [
+          { key: 'Cache-Control', value: 'public, s-maxage=300, stale-while-revalidate=86400, max-age=0' },
+        ],
+      },
+      {
         source: '/blogs/:path*',
         headers: [
           { key: 'Cache-Control', value: 'public, s-maxage=3600, stale-while-revalidate=86400, max-age=0' },

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -3,6 +3,10 @@ import Index from '@/components/Index/Index';
 import Sidebar from '@/components/SIdebar/Sidebar'; // Sidebarのimportを修正
 import Title from '@/components/Title/Title';
 
+// Home と同様、ビルド時プリレンダだと新記事がデプロイまで出ないため Edge Runtime にする。
+// 鮮度は next.config.js の /blogs/:path* の Cache-Control で制御。
+export const runtime = 'edge';
+
 export default async function StaticPage() {
   const { contents } = await getList();
   //console.log(contents);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,6 +32,12 @@ export const metadata = {
   },
 };
 
+// Edge Runtime でリクエスト時にNotionから取得する。
+// ビルド時プリレンダのままだと新記事がデプロイまで反映されないため
+// （Cloudflare Pages では ISR / revalidate が使えないので Edge + CDNキャッシュで代替）。
+// 鮮度は next.config.js の Cache-Control（s-maxage）で制御する。
+export const runtime = 'edge';
+
 export default async function StaticPage() {
   const [{ contents }, categoryData] = await Promise.all([
     getList(),


### PR DESCRIPTION
## 問題

記事を公開しても、Home (`/`) と Blog一覧 (`/blogs`) に**デプロイし直すまで反映されない**。

本番のレスポンスヘッダで原因を確認しました。

```
x-nextjs-prerender: 1              ← ビルド時プリレンダ済みの静的HTML
x-nextjs-stale-time: 4294967294    ← 再検証されない(2^32-1)
```

CDNキャッシュの問題ではなく、ページ自体がビルド時のデータで固定されていました。記事詳細・カテゴリ別・タグ別には `export const runtime = 'edge'` があるのに、Home と Blog一覧だけ抜けていたのが原因です。

## 採用しなかった案

**ISR (`export const revalidate`)** — `claude.md` に記載のとおり Cloudflare Pages では使用不可。

**`libs/notion.ts` の `notionFetch` に `next: { revalidate }` を渡す** — 関数シグネチャに `revalidate?: number` の口はあるが未実装。ただしDB取得は `POST /databases/{id}/query` で、**Next.js は POST をデータキャッシュしない**ため、実装しても効きません。

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/app/page.tsx` | `export const runtime = 'edge'` を追加 |
| `src/app/blogs/page.tsx` | 同上 |
| `next.config.js` | `/` の `Cache-Control` を追加(`s-maxage=300`) |

Edge Runtime でリクエスト時にNotionから取得し、鮮度は CDN の `s-maxage` で制御する = ISR相当の挙動になります。トップは新着の鮮度を優先して5分、既存の一覧系は従来どおり1時間です。

## 検証

`next build` で `/` と `/blogs` が `ƒ (Dynamic) server-rendered on demand` になることを確認(変更前は `○ Static`)。

`npx @cloudflare/next-on-pages` も通り、Edge Function 側に `/index` と `/blogs` が入り、**invalid functions は 0 件**でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvyMGud73qCfUibGvAy1YP