### PR TITLE
fix: Notion→Markdown変換で消えていた記事コンテンツを復旧する

### DIFF
--- a/libs/notion.ts
+++ b/libs/notion.ts
@@ -93,8 +93,8 @@ function pageToCategory(name: string): Category {
   return { id, name, createdAt: now, updatedAt: now, publishedAt: now, revisedAt: now };
 }
 
-// Notionのブロックをマークダウンに変換
-async function blocksToMarkdown(blockId: string): Promise<string> {
+// 子ブロックを全件取得する（Notion APIは1回あたり最大100件しか返さない）
+async function fetchAllChildren(blockId: string): Promise<any[]> {
   const blocks: any[] = [];
   let cursor: string | undefined;
 
@@ -106,123 +106,158 @@ async function blocksToMarkdown(blockId: string): Promise<string> {
     cursor = response.has_more ? response.next_cursor : undefined;
   } while (cursor);
 
-  const lines: string[] = [];
+  return blocks;
+}
+
+// リスト系ブロックが連続する場合は空行を挟まない。
+// 空行を挟むとmarkdown-itがloose list扱いにして各項目を<p>で包むため、行間が崩れる。
+const LIST_BLOCK_TYPES = new Set(['bulleted_list_item', 'numbered_list_item', 'to_do']);
+
+// Markdownのテーブルは | をセル区切りとして解釈するため、セル内の | はエスケープする。
+// 改行もテーブルを壊すので <br> に置き換える。
+function escapeTableCell(text: string): string {
+  return text.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
+}
+
+// リスト項目と、その子ブロックを字下げして返す。
+// CommonMarkでは子リストを親マーカーの文字数ぶん字下げする必要がある（"- "なら2、"1. "なら3）。
+async function listItemToMarkdown(
+  block: any,
+  indent: string,
+  marker: string,
+  body: string
+): Promise<string> {
+  const line = `${indent}${marker}${body}`;
+  if (!block.has_children) return line;
+  const children = await blocksToMarkdown(block.id, indent + ' '.repeat(marker.length));
+  return children ? `${line}\n${children}` : line;
+}
+
+// 1ブロックをMarkdownに変換する。出力する必要のないブロックは null を返す。
+async function blockToMarkdown(block: any, indent: string): Promise<string | null> {
+  switch (block.type) {
+    case 'heading_1':
+      return `${indent}# ${stripEmoji(richTextToPlain(block.heading_1.rich_text))}`;
+    case 'heading_2': {
+      const h2Text = stripEmoji(richTextToPlain(block.heading_2.rich_text));
+      // 「目次」見出しはスキップ（ブログ側で自動生成するため）
+      if (h2Text === '目次') return null;
+      return `${indent}## ${h2Text}`;
+    }
+    case 'heading_3':
+      return `${indent}### ${stripEmoji(richTextToPlain(block.heading_3.rich_text))}`;
+    case 'paragraph':
+      return `${indent}${richTextToMarkdown(block.paragraph.rich_text)}`;
+    case 'bulleted_list_item':
+      return listItemToMarkdown(block, indent, '- ', richTextToMarkdown(block.bulleted_list_item.rich_text));
+    case 'numbered_list_item':
+      return listItemToMarkdown(block, indent, '1. ', richTextToMarkdown(block.numbered_list_item.rich_text));
+    case 'to_do': {
+      // チェックボックスは表示専用。<li>のクラス付けはレンダリング側で行う。
+      const checked = block.to_do.checked ? ' checked' : '';
+      const body = `<input type="checkbox" disabled${checked}> ${richTextToMarkdown(block.to_do.rich_text)}`;
+      return listItemToMarkdown(block, indent, '- ', body);
+    }
+    case 'code': {
+      const code = richTextToPlain(block.code.rich_text)
+        .split('\n')
+        .map((line: string) => `${indent}${line}`)
+        .join('\n');
+      return `${indent}\`\`\`${block.code.language || ''}\n${code}\n${indent}\`\`\``;
+    }
+    case 'image': {
+      const url = block.image.type === 'external'
+        ? block.image.external.url
+        : block.image.file.url;
+      const caption = block.image.caption ? richTextToPlain(block.image.caption) : '';
+      return `${indent}![${caption}](${url})`;
+    }
+    case 'bookmark':
+      return block.bookmark.url ? `${indent}${block.bookmark.url}` : null;
+    case 'divider':
+      return `${indent}---`;
+    case 'quote': {
+      // 引用は blockquote として出力する。calloutに変換すると補足Tipsと見分けがつかなくなる。
+      const text = richTextToMarkdown(block.quote.rich_text);
+      const children = block.has_children ? await blocksToMarkdown(block.id) : '';
+      const body = children ? `${text}\n\n${children}` : text;
+      return body
+        .split('\n')
+        .map((line) => `${indent}>${line ? ` ${line}` : ''}`)
+        .join('\n');
+    }
+    case 'callout': {
+      const icon = block.callout.icon?.emoji || 'ℹ️';
+      const color = block.callout.color || 'default';
+      const text = richTextToMarkdown(block.callout.rich_text);
+      const children = block.has_children ? await blocksToMarkdown(block.id) : '';
+      const body = children ? `${text}\n\n${children}` : text;
+      // ::: マーカーはレンダリング側が行頭のものだけを拾うため、字下げしない。
+      // リスト内のcalloutはリストから抜けた見た目になるが、マーカーが壊れるよりは良い。
+      return `:::callout{icon="${icon}" color="${color}"}\n${body}\n:::`;
+    }
+    case 'toggle': {
+      // 折りたたみは <details> にする。子ブロックを取らないと中身が丸ごと消えてしまう。
+      const summary = richTextToMarkdown(block.toggle.rich_text);
+      const children = block.has_children ? await blocksToMarkdown(block.id, indent) : '';
+      if (!children) return `${indent}${summary}`;
+      // 前後に空行を挟むことで、<details>内のMarkdownがそのまま解釈される
+      return `${indent}<details>\n${indent}<summary>${summary}</summary>\n\n${children}\n\n${indent}</details>`;
+    }
+    case 'table_of_contents':
+      // 目次は自動生成するのでスキップ
+      return null;
+    case 'table': {
+      const rows = (await fetchAllChildren(block.id)).filter((row: any) => row.type === 'table_row');
+      if (rows.length === 0) return null;
+
+      const width: number = block.table?.table_width ?? rows[0].table_row.cells.length;
+      const hasHeader: boolean = block.table?.has_column_header ?? true;
+      const toRow = (cells: any[]) =>
+        `${indent}| ${Array.from({ length: width }, (_, i) =>
+          escapeTableCell(richTextToMarkdown(cells[i] ?? []))
+        ).join(' | ')} |`;
+      const separator = `${indent}| ${Array.from({ length: width }, () => '---').join(' | ')} |`;
+
+      const lines: string[] = [];
+      if (hasHeader) {
+        lines.push(toRow(rows[0].table_row.cells), separator);
+        rows.slice(1).forEach((row: any) => lines.push(toRow(row.table_row.cells)));
+      } else {
+        // Markdownのテーブルはヘッダー行が必須なので、空のヘッダーを置いて全行をデータとして扱う
+        lines.push(`${indent}|${' |'.repeat(width)}`, separator);
+        rows.forEach((row: any) => lines.push(toRow(row.table_row.cells)));
+      }
+      return lines.join('\n');
+    }
+    default:
+      // 未対応ブロックは出力できないため、開発時に気づけるよう警告する
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(`[notion] 未対応のブロックをスキップしました: type=${block.type} id=${block.id}`);
+      }
+      return null;
+  }
+}
+
+// Notionのブロックをマークダウンに変換
+// indent はリストのネスト表現に使う
+async function blocksToMarkdown(blockId: string, indent = ''): Promise<string> {
+  const blocks = await fetchAllChildren(blockId);
+  const parts: { type: string; text: string }[] = [];
 
   for (const block of blocks) {
-    switch (block.type) {
-      case 'heading_1':
-        lines.push(`# ${stripEmoji(richTextToPlain(block.heading_1.rich_text))}`);
-        break;
-      case 'heading_2': {
-        const h2Text = stripEmoji(richTextToPlain(block.heading_2.rich_text));
-        // 「目次」見出しはスキップ（ブログ側で自動生成するため）
-        if (h2Text === '目次') break;
-        lines.push(`## ${h2Text}`);
-        break;
-      }
-      case 'heading_3':
-        lines.push(`### ${stripEmoji(richTextToPlain(block.heading_3.rich_text))}`);
-        break;
-      case 'paragraph':
-        lines.push(richTextToMarkdown(block.paragraph.rich_text));
-        break;
-      case 'bulleted_list_item':
-        lines.push(`- ${richTextToMarkdown(block.bulleted_list_item.rich_text)}`);
-        break;
-      case 'numbered_list_item':
-        lines.push(`1. ${richTextToMarkdown(block.numbered_list_item.rich_text)}`);
-        break;
-      case 'code':
-        lines.push(`\`\`\`${block.code.language || ''}\n${richTextToPlain(block.code.rich_text)}\n\`\`\``);
-        break;
-      case 'image': {
-        const url = block.image.type === 'external'
-          ? block.image.external.url
-          : block.image.file.url;
-        const caption = block.image.caption ? richTextToPlain(block.image.caption) : '';
-        lines.push(`![${caption}](${url})`);
-        break;
-      }
-      case 'bookmark':
-        lines.push(block.bookmark.url || '');
-        break;
-      case 'divider':
-        // 区切り線は出力しない（見出しで十分区切られるため）
-        break;
-      case 'quote': {
-        const quoteText = richTextToMarkdown(block.quote.rich_text);
-        const quoteColor = block.quote.color || 'default';
-        // quoteの子ブロック（リスト等）を取得
-        let quoteChildContent = '';
-        if (block.has_children) {
-          const childBlocks = await notionFetch(`/blocks/${block.id}/children?page_size=100`);
-          for (const child of childBlocks.results) {
-            if (child.type === 'bulleted_list_item') {
-              quoteChildContent += `\n- ${richTextToMarkdown(child.bulleted_list_item.rich_text)}`;
-            } else if (child.type === 'numbered_list_item') {
-              quoteChildContent += `\n1. ${richTextToMarkdown(child.numbered_list_item.rich_text)}`;
-            } else if (child.type === 'paragraph') {
-              quoteChildContent += `\n${richTextToMarkdown(child.paragraph.rich_text)}`;
-            }
-          }
-        }
-        lines.push(`:::callout{icon="📌" color="${quoteColor === 'default' ? 'gray_background' : quoteColor}"}`);
-        lines.push(quoteText + quoteChildContent);
-        lines.push(':::');
-        break;
-      }
-      case 'callout': {
-        const icon = block.callout.icon?.emoji || 'ℹ️';
-        const text = richTextToMarkdown(block.callout.rich_text);
-        const color = block.callout.color || 'default';
-        // calloutの子ブロック（リスト等）を取得
-        let childContent = '';
-        if (block.has_children) {
-          const childBlocks = await notionFetch(`/blocks/${block.id}/children?page_size=100`);
-          for (const child of childBlocks.results) {
-            if (child.type === 'bulleted_list_item') {
-              childContent += `\n- ${richTextToMarkdown(child.bulleted_list_item.rich_text)}`;
-            } else if (child.type === 'numbered_list_item') {
-              childContent += `\n1. ${richTextToMarkdown(child.numbered_list_item.rich_text)}`;
-            } else if (child.type === 'paragraph') {
-              childContent += `\n${richTextToMarkdown(child.paragraph.rich_text)}`;
-            }
-          }
-        }
-        lines.push(`:::callout{icon="${icon}" color="${color}"}`);
-        lines.push(text + childContent);
-        lines.push(':::');
-        break;
-      }
-      case 'toggle':
-        lines.push(richTextToMarkdown(block.toggle.rich_text));
-        break;
-      case 'table_of_contents':
-        // 目次は自動生成するのでスキップ
-        break;
-      case 'table': {
-        // テーブルの子ブロック(行)を取得
-        const tableRows = await notionFetch(`/blocks/${block.id}/children`);
-        const rows = tableRows.results as any[];
-        rows.forEach((row: any, idx: number) => {
-          if (row.type === 'table_row') {
-            const cells = row.table_row.cells.map((cell: any[]) => richTextToPlain(cell));
-            lines.push(`| ${cells.join(' | ')} |`);
-            if (idx === 0) {
-              lines.push(`| ${cells.map(() => '---').join(' | ')} |`);
-            }
-          }
-        });
-        break;
-      }
-      default:
-        // 未対応ブロックはスキップ
-        break;
-    }
-    lines.push('');
+    const text = await blockToMarkdown(block, indent);
+    if (text === null) continue;
+    parts.push({ type: block.type, text });
   }
 
-  return lines.join('\n');
+  return parts
+    .map((part, i) => {
+      if (i === 0) return part.text;
+      const tight = LIST_BLOCK_TYPES.has(part.type) && LIST_BLOCK_TYPES.has(parts[i - 1].type);
+      return `${tight ? '\n' : '\n\n'}${part.text}`;
+    })
+    .join('');
 }
 
 // rich_textをマークダウン形式に変換 (インライン装飾対応)
@@ -231,10 +266,17 @@ function richTextToMarkdown(richText: any[]): string {
   if (!richText) return '';
   return richText.map((t: any) => {
     let text = t.plain_text;
-    if (t.annotations?.code) text = `\`${text}\``;
-    if (t.annotations?.bold) text = `<strong>${text}</strong>`;
-    if (t.annotations?.italic) text = `<em>${text}</em>`;
-    if (t.annotations?.strikethrough) text = `<del>${text}</del>`;
+    const annotations = t.annotations || {};
+    if (annotations.code) text = `\`${text}\``;
+    if (annotations.bold) text = `<strong>${text}</strong>`;
+    if (annotations.italic) text = `<em>${text}</em>`;
+    if (annotations.strikethrough) text = `<del>${text}</del>`;
+    if (annotations.underline) text = `<u>${text}</u>`;
+    // 背景色ハイライトのみ <mark> として残す。
+    // 文字色はサイトの配色を壊すため反映しない。
+    if (typeof annotations.color === 'string' && annotations.color.endsWith('_background')) {
+      text = `<mark class="mark-${annotations.color.replace('_background', '')}">${text}</mark>`;
+    }
     if (t.href) text = `[${text}](${t.href})`;
     return text;
   }).join('');

--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -186,12 +186,14 @@ export default async function StaticDetailPage({
     .map(({ post }) => post);
   
   // calloutマーカーをプレースホルダーに変換（markdownToHtmlに通す前）
+  // 前後を %% で囲うのは、CALLOUT1 が CALLOUT10 の先頭にマッチして
+  // 11個目以降のcalloutが壊れるのを防ぐため
   const calloutMap = new Map<string, { icon: string; color: string; text: string }>();
   let calloutIndex = 0;
   const bodyPreprocessed = blog.body.replace(
     /:::callout\{icon="([^"]*)" color="([^"]*)"\}\n([\s\S]*?)\n:::/g,
     (_, icon, color, text) => {
-      const placeholder = `CALLOUT_PLACEHOLDER_${calloutIndex++}`;
+      const placeholder = `%%CALLOUT${calloutIndex++}%%`;
       calloutMap.set(placeholder, { icon, color, text });
       return placeholder;
     }
@@ -203,10 +205,19 @@ export default async function StaticDetailPage({
   let processedHtml = html;
   calloutMap.forEach(({ icon, color, text }, placeholder) => {
     // テキスト先頭の絵文字がiconと重複する場合は除去
-    let cleanText = text.replace(/^[\u{1F300}-\u{1F9FF}\u{2600}-\u{27BF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]+\s*/u, '').trim();
-    const textHtml = md.render(cleanText).replace(/<\/?p>/g, '').trim();
-    const calloutHtml = `<div class="callout callout-${color}"><span class="callout-icon">${icon}</span><div class="callout-content">${textHtml}</div></div>`;
-    processedHtml = processedHtml.replace(new RegExp(`<p>${placeholder}</p>|${placeholder}`, 'g'), calloutHtml);
+    const cleanText = text.replace(/^[\u{1F300}-\u{1F9FF}\u{2600}-\u{27BF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]+\s*/u, '').trim();
+    const rendered = md.render(cleanText).trim();
+    // 単一段落のときだけ <p> を外す。
+    // 無条件に全ての <p> を除去すると、複数段落のcalloutが1段落に潰れてしまう。
+    const isSingleParagraph =
+      /^<p>[\s\S]*<\/p>$/.test(rendered) && !rendered.slice(3, -4).includes('<p>');
+    const textHtml = isSingleParagraph ? rendered.slice(3, -4) : rendered;
+    const calloutHtml = `<div class="callout callout-${color}"><span class="callout-icon" aria-hidden="true">${icon}</span><div class="callout-content">${textHtml}</div></div>`;
+    // 置換文字列を関数で渡し、本文中の $& などが置換パターンとして解釈されるのを防ぐ
+    processedHtml = processedHtml.replace(
+      new RegExp(`<p>${placeholder}</p>|${placeholder}`, 'g'),
+      () => calloutHtml
+    );
   });
 
   // [toc]マーカーを除去（ブログ側で目次を自動生成するため）
@@ -214,6 +225,13 @@ export default async function StaticDetailPage({
   processedHtml = processedHtml.replace(/<p>\s*"\[toc\]"\s*<\/p>/gi, '');
   processedHtml = processedHtml.replace(/"\[toc\]"/gi, '');
   processedHtml = processedHtml.replace(/\[toc\]/gi, '');
+
+  // 見出し行を持たないNotionテーブルは、Markdownの制約上ダミーの空ヘッダーを挟んでいる。
+  // 空のままだと灰色の帯だけが残るので取り除く。
+  processedHtml = processedHtml.replace(
+    /<thead>\s*<tr>(?:\s*<th[^>]*>\s*<\/th>)+\s*<\/tr>\s*<\/thead>/g,
+    ''
+  );
 
   // テーブルをスクロール可能なラッパーで囲む（モバイル対応）
   processedHtml = processedHtml.replace(
@@ -232,6 +250,12 @@ export default async function StaticDetailPage({
   processedHtml = processedHtml.replace(
     /<img(?![^>]*loading=)/g,
     '<img loading="lazy" decoding="async"'
+  );
+
+  // チェックリスト(to_do)の <li> にクラスを付ける（マーカー除去とインデント調整のため）
+  processedHtml = processedHtml.replace(
+    /<li>(\s*<input type="checkbox")/g,
+    '<li class="task-list-item">$1'
   );
 
   // リンクカード生成（正規表現ベース）

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -219,25 +219,125 @@
   opacity: 1;
 }
 
+/* 引用: 縦線のみで表現する。
+   callout（背景付きボックス）と役割を視覚的に分けるため背景は敷かない。
+   日本語には斜体字形がなく合成斜体になって読みにくいので font-style も使わない。 */
 .znc blockquote {
-  border-left: 4px solid #94a3b8;
-  padding: 0.75rem 1rem;
-  margin: 1.5rem 0;
-  background: #f8fafc;
-  border-radius: 0 8px 8px 0;
-  font-style: italic;
-  color: #475569;
+  border-left: 3px solid #cbd5e1;
+  padding: 0.25rem 0 0.25rem 1.25rem;
+  margin: 1.75rem 0;
+  background: none;
+  font-style: normal;
+  color: inherit;
 }
 .dark .znc blockquote {
-  border-left-color: #60a5fa;
-  background: rgba(30, 41, 59, 0.5);
+  border-left-color: #475569;
+}
+.znc blockquote > :first-child {
+  margin-top: 0;
+}
+.znc blockquote > :last-child {
+  margin-bottom: 0;
+}
+.znc blockquote cite {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.875em;
+  font-style: normal;
+  color: #64748b;
+}
+.dark .znc blockquote cite {
   color: #94a3b8;
 }
+.znc blockquote cite::before {
+  content: '— ';
+}
 
+/* 折りたたみ（Notionのトグル） */
+.znc details {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin: 1.5rem 0;
+}
+.dark .znc details {
+  border-color: #334155;
+}
+.znc summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+}
+.znc summary::-webkit-details-marker {
+  display: none;
+}
+.znc summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.5em;
+  color: #94a3b8;
+  transition: transform 0.2s;
+}
+.znc details[open] > summary::before {
+  transform: rotate(90deg);
+}
+.znc details[open] > summary {
+  margin-bottom: 0.75rem;
+}
+
+/* チェックリスト（Notionのto_do） */
+.znc li.task-list-item {
+  list-style: none;
+  margin-left: -1.25em;
+}
+.znc li.task-list-item input[type='checkbox'] {
+  margin-right: 0.4em;
+  accent-color: #3b82f6;
+  /* 表示専用。読者が状態を変えられるようには見せない */
+  pointer-events: none;
+}
+
+/* Notionの背景色ハイライト */
+.znc mark {
+  background: rgba(250, 204, 21, 0.35);
+  color: inherit;
+  padding: 0.1em 0.2em;
+  border-radius: 3px;
+}
+.dark .znc mark {
+  background: rgba(250, 204, 21, 0.25);
+}
+.znc mark.mark-blue {
+  background: rgba(59, 130, 246, 0.25);
+}
+.znc mark.mark-green {
+  background: rgba(34, 197, 94, 0.25);
+}
+.znc mark.mark-red {
+  background: rgba(239, 68, 68, 0.25);
+}
+.znc mark.mark-purple {
+  background: rgba(168, 85, 247, 0.25);
+}
+.znc mark.mark-pink {
+  background: rgba(236, 72, 153, 0.25);
+}
+.znc mark.mark-orange {
+  background: rgba(249, 115, 22, 0.25);
+}
+.znc mark.mark-gray,
+.znc mark.mark-brown {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+/* 区切り線。--border はHSL値なので rgb() では解釈されず、以前は色が効いていなかった */
 .znc hr {
   border: none;
-  border-top: 2px solid rgb(var(--border));
-  margin: 1.5rem 0;
+  border-top: 1px solid #e2e8f0;
+  margin: 3rem 0;
+}
+.dark .znc hr {
+  border-top-color: #334155;
 }
 
 .znc img {
@@ -428,9 +528,13 @@
   min-width: 0;
 }
 
+/* 複数段落のcalloutでも段落の区切りが分かるようにする */
 .znc .callout-content p {
   padding: 0;
-  margin: 0;
+  margin: 0 0 0.75em;
+}
+.znc .callout-content > :last-child {
+  margin-bottom: 0;
 }
 
 .znc .callout-content strong {


### PR DESCRIPTION
## What

Notionで書いた内容が公開ページに出ないまま放置されていた変換バグをまとめて修正しました。あわせて、11個以上のcalloutを含む記事が壊れる問題と、引用のデザインを直しています。

Closes #419, #420, #423, #426, #429, #430, #431, #439, #440, #441, #442, #443, #459, #460, #339

## Why

`libs/notion.ts` の `blocksToMarkdown` が子ブロックを辿っておらず、複数のブロック種別で**コンテンツが黙って消えていました**。Notion上では正しく見えるため、書き手が欠落に気づけないのが厄介な点です。

| ブロック | これまでの挙動 |
|---|---|
| `quote` | **calloutに変換**され、引用と補足Tipsが同じ📌グレーボックスで表示。`.znc blockquote` は一度も使われないデッドCSSだった |
| `toggle` | 見出し行だけ出力し、**中身が丸ごと消失** |
| ネストしたリスト | `has_children` を見ておらず**子項目が消失** |
| `divider` | 出力なし（`.znc hr` もデッドCSS） |
| `to_do` | 未対応で消失 |
| `table` | セルが `richTextToPlain` を通るため**インラインコード・太字・リンクが消える**。`\|` を含むセルで**表が崩壊**。101行目以降が消失。`has_column_header` 無視で**データ行がヘッダーになる** |
| `underline` / 背景ハイライト | 無視 |
| 未対応ブロック | 警告もログもなくスキップ |

さらにレンダリング側で、calloutのプレースホルダが `CALLOUT_PLACEHOLDER_1` のような裸の連番だったため、**`_1` が `_10` の先頭にマッチ**していました。callout を11個以上使った記事は必ず壊れます（別のcalloutの内容が重複表示され、1つ消える）。手元で再現を確認しています。

## How

- `blocksToMarkdown(blockId, indent)` を**再帰化**し、全ブロック種別で子を辿るように変更。リストのネストはCommonMarkに従い親マーカーの文字数ぶん字下げ（`- `→2、`1. `→3）
- 連続するリスト項目の間に空行を入れないように分岐。空行があるとmarkdown-itがloose list化して各項目を`<p>`で包み、行間が崩れるため
- `quote` は `> ` の blockquote として出力。callout との役割を分離
- `toggle` は `<details>`/`<summary>`。前後に空行を挟むことで中のMarkdownが解釈される
- テーブルはページネーション対応 + `table_width`/`has_column_header` を参照 + セルの `|` を `\|` にエスケープ + `richTextToMarkdown` を使用。ヘッダー行を持たない表はMarkdownの制約上ダミーの空ヘッダーを置き、レンダリング後に空`<thead>`を除去
- 未対応ブロックは開発時のみ `console.warn`
- calloutのプレースホルダを `%%CALLOUT0%%` 形式に変更して前方一致を防止。置換値を**関数で渡し**、本文中の `$&` が置換パターンとして解釈されるのも回避
- calloutの `<p>` 一括除去をやめ、**単一段落のときだけ**アンラップ（複数段落が1段落に潰れていた）

### 検証

Notion APIのレスポンス形状を模したデータで変換結果を確認しました。

- callout 12個 → 12個すべて正しく配置、取りこぼしゼロ
- `` `string | number` `` を含むセル → `<code>string | number</code>` として正しく描画
- ヘッダーなしテーブル → 空`<thead>`が除去され、通常のヘッダー付きテーブルは影響を受けない
- ネストしたリスト・チェックリスト・`<details>`内のコードブロック → いずれも期待通り

なお、当初 #459 として「インラインコードとリンクの併用が壊れる」と起票していましたが、**実挙動を検証した結果その問題は存在しませんでした**。Issueは実際に残っていた `underline` 欠落の内容に訂正済みです。

## Changed Files

- `libs/notion.ts` — `blocksToMarkdown` の再帰化、各ブロック種別の変換修正
- `src/app/blogs/[blogId]/page.tsx` — calloutプレースホルダ、複数段落callout、空`<thead>`除去、チェックリストのクラス付与
- `styles/markdown.css` — blockquote / details / task list / mark のスタイル、`hr` の色指定修正

## Testing

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npm run lint` — 新規warningなし（既存の `no-img-element` のみ）
- [x] 変換ロジックをモックデータで検証（上記）
- [x] ライトモード/ダークモード両方のスタイルを追加
- [ ] 実記事での表示確認（CIビルド後）

## Screenshots

CSSの変更点（実データでの確認はデプロイ後）:

- **引用**: 背景・角丸・斜体をやめ、左の縦線のみに。日本語には斜体字形がないため合成斜体になって読みにくかった
- **区切り線**: `rgb(var(--border))` はHSL値をrgb()に渡していて色として解釈されていなかったため修正
- **details / チェックリスト / ハイライト**: 新規追加

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_