### PR TITLE
perf: Notion APIの往復・Workerバンドル・スクロール時のレイアウト計算を削減する

### DIFF
--- a/libs/notion.ts
+++ b/libs/notion.ts
@@ -1,3 +1,5 @@
+import { cache } from 'react';
+
 // Notion REST API を直接fetch（Edge Runtime互換、@notionhq/client不使用）
 const NOTION_API_BASE = 'https://api.notion.com/v1';
 const NOTION_VERSION = '2022-06-28';
@@ -60,11 +62,6 @@ const DATABASE_ID = process.env.NOTION_DATABASE_ID || '2eca0ffb73d181ffba0aecf7c
 if (!process.env.NOTION_API_KEY) {
   throw new Error('NOTION_API_KEY is required');
 }
-
-// notionFetchを使用（上で定義済み）
-
-// ビルド時のAPI呼び出し削減用キャッシュ
-let listCache: { contents: Blog[]; totalCount: number; offset: number; limit: number } | null = null;
 
 // Notionのrich_textからプレーンテキストを取得
 function richTextToPlain(richText: any[]): string {
@@ -317,13 +314,11 @@ async function pageToBlog(page: any, fetchBody: boolean = false): Promise<Blog> 
   };
 }
 
-// ブログ一覧を取得（キャッシュ付き）
-export const getList = async (queries?: { limit?: number; orders?: string }) => {
-  if (listCache) {
-    const limit = queries?.limit || 100;
-    return { ...listCache, contents: listCache.contents.slice(0, limit), limit };
-  }
-
+// ブログ一覧を取得
+// cache() で同一リクエスト内のみメモ化する。
+// 以前はモジュールスコープの変数に貯めていたが、Cloudflare Workers の isolate は
+// 複数リクエストで再利用されるため、生きている isolate では古い一覧が返り続けていた。
+export const getList = cache(async () => {
   const allPages: any[] = [];
   let cursor: string | undefined;
 
@@ -341,14 +336,12 @@ export const getList = async (queries?: { limit?: number; orders?: string }) => 
 
   const contents = await Promise.all(allPages.map((page) => pageToBlog(page, false)));
 
-  listCache = { contents, totalCount: contents.length, offset: 0, limit: contents.length };
-
-  const limit = queries?.limit || 100;
-  return { contents: contents.slice(0, limit), totalCount: contents.length, offset: 0, limit };
-};
+  return { contents, totalCount: contents.length, offset: 0, limit: contents.length };
+});
 
 // ブログの詳細を取得 (slugで検索)
-export const getDetail = async (slug: string) => {
+// generateMetadata と本体の両方から呼ばれるため、メモ化しないとNotion APIを2往復する
+export const getDetail = cache(async (slug: string) => {
   // まずSlugプロパティで検索
   const response = await notionFetch(`/databases/${DATABASE_ID}/query`, {
     method: 'POST',
@@ -366,18 +359,21 @@ export const getDetail = async (slug: string) => {
   }
 
   return pageToBlog(response.results[0], true);
-};
+});
+
+// データベースのスキーマ（タグ・カテゴリの選択肢）を取得
+// getTagList / getCategoryList / それぞれのDetail から呼ばれるので、
+// メモ化しないと1ページの描画で同じスキーマを4回取りに行くことになる
+const getDatabaseSchema = cache(async () => notionFetch(`/databases/${DATABASE_ID}`));
 
 // タグ一覧を取得
-export const getTagList = async () => {
-  // Notionのデータベーススキーマからタグオプションを取得
-  const db = await notionFetch(`/databases/${DATABASE_ID}`);
-  const tagsProperty = (db.properties as any).Tags;
-  const options = tagsProperty?.multi_select?.options || [];
+export const getTagList = cache(async () => {
+  const db = await getDatabaseSchema();
+  const options = (db.properties as any).Tags?.multi_select?.options || [];
 
   const contents: Tag[] = options.map((opt: any) => pageToTag(opt.name));
   return { contents, totalCount: contents.length, offset: 0, limit: contents.length };
-};
+});
 
 // タグの詳細を取得
 export const getTagDetail = async (tagId: string) => {
@@ -389,14 +385,13 @@ export const getTagDetail = async (tagId: string) => {
 };
 
 // カテゴリ一覧を取得
-export const getCategoryList = async () => {
-  const db = await notionFetch(`/databases/${DATABASE_ID}`);
-  const categoryProperty = (db.properties as any).Category;
-  const options = categoryProperty?.select?.options || [];
+export const getCategoryList = cache(async () => {
+  const db = await getDatabaseSchema();
+  const options = (db.properties as any).Category?.select?.options || [];
 
   const contents: Category[] = options.map((opt: any) => pageToCategory(opt.name));
   return { contents, totalCount: contents.length, offset: 0, limit: contents.length };
-};
+});
 
 // カテゴリの詳細を取得
 export const getCategoryDetail = async (categoryId: string) => {

--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -6,28 +6,92 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCalendarAlt, faTag } from '@fortawesome/free-solid-svg-icons';
 import MarkdownIt from 'markdown-it';
 import anchor from 'markdown-it-anchor';
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/core';
 import '../../../../styles/markdown.css';
 import '../../../../styles/hljs-theme.css';
+
+// highlight.js の既定エントリは190以上の言語定義を含み、Workersのバンドルサイズを圧迫する。
+// 記事で実際に使う言語だけを登録する。
+import bash from 'highlight.js/lib/languages/bash';
+import css from 'highlight.js/lib/languages/css';
+import diff from 'highlight.js/lib/languages/diff';
+import dockerfile from 'highlight.js/lib/languages/dockerfile';
+import go from 'highlight.js/lib/languages/go';
+import graphql from 'highlight.js/lib/languages/graphql';
+import ini from 'highlight.js/lib/languages/ini';
+import java from 'highlight.js/lib/languages/java';
+import javascript from 'highlight.js/lib/languages/javascript';
+import json from 'highlight.js/lib/languages/json';
+import markdown from 'highlight.js/lib/languages/markdown';
+import php from 'highlight.js/lib/languages/php';
+import python from 'highlight.js/lib/languages/python';
+import ruby from 'highlight.js/lib/languages/ruby';
+import rust from 'highlight.js/lib/languages/rust';
+import scss from 'highlight.js/lib/languages/scss';
+import sql from 'highlight.js/lib/languages/sql';
+import typescript from 'highlight.js/lib/languages/typescript';
+import xml from 'highlight.js/lib/languages/xml';
+import yaml from 'highlight.js/lib/languages/yaml';
+
+const LANGUAGES: Record<string, any> = {
+  bash, css, diff, dockerfile, go, graphql, java, javascript, json, markdown,
+  php, python, ruby, rust, scss, sql, typescript, xml, yaml,
+  ini, // toml も ini で色付けできる
+};
+Object.entries(LANGUAGES).forEach(([name, lang]) => hljs.registerLanguage(name, lang));
+// よく使われる別名
+hljs.registerAliases(['sh', 'shell', 'zsh'], { languageName: 'bash' });
+hljs.registerAliases(['js', 'jsx'], { languageName: 'javascript' });
+hljs.registerAliases(['ts', 'tsx'], { languageName: 'typescript' });
+hljs.registerAliases(['html', 'vue', 'svg'], { languageName: 'xml' });
+hljs.registerAliases(['yml'], { languageName: 'yaml' });
+hljs.registerAliases(['toml'], { languageName: 'ini' });
+hljs.registerAliases(['py'], { languageName: 'python' });
+hljs.registerAliases(['rb'], { languageName: 'ruby' });
 
 function escapeHtml(str: string): string {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+// コードブロック右上に出す言語ラベル。
+// 以前はCSSに言語ごとの ::before をハードコードしていたため、
+// 列挙外の言語ではラベルが空文字になり、余白だけが2em空いていた。
+// 別名も含めて引けるようにしておく。
+// hljs.getLanguage().name は "HTML, XML" のような文字列を返すことがあり、正規化には使えない。
+const LANG_LABELS: Record<string, string> = {
+  bash: 'Bash', sh: 'Bash', shell: 'Bash', zsh: 'Bash',
+  css: 'CSS', scss: 'SCSS',
+  diff: 'Diff', dockerfile: 'Dockerfile',
+  go: 'Go', graphql: 'GraphQL',
+  ini: 'INI', toml: 'TOML',
+  java: 'Java',
+  javascript: 'JavaScript', js: 'JavaScript', jsx: 'JSX',
+  typescript: 'TypeScript', ts: 'TypeScript', tsx: 'TSX',
+  json: 'JSON', markdown: 'Markdown',
+  php: 'PHP',
+  python: 'Python', py: 'Python',
+  ruby: 'Ruby', rb: 'Ruby',
+  rust: 'Rust', sql: 'SQL',
+  xml: 'XML', html: 'HTML', vue: 'Vue', svg: 'SVG',
+  yaml: 'YAML', yml: 'YAML',
+};
+
 const md: MarkdownIt = new MarkdownIt({
   html: true,
   linkify: true,
-  typographer: true,
+  // typographer は "..." を … に、-- を – に変換してしまう。
+  // 技術記事ではコマンドやJSONの引用符が壊れるため無効にする。
+  typographer: false,
   highlight: (str: string, lang: string): string => {
     if (lang && hljs.getLanguage(lang)) {
       try {
-        return `<pre><code class="hljs language-${lang}">${hljs.highlight(str, { language: lang }).value}</code></pre>`;
+        const label = LANG_LABELS[lang.toLowerCase()] ?? lang.toUpperCase();
+        return `<pre class="has-lang" role="region" aria-label="${escapeHtml(label)}のコード"><code class="hljs language-${lang}" data-lang="${escapeHtml(label)}">${hljs.highlight(str, { language: lang }).value}</code></pre>`;
       } catch { /* fallthrough */ }
     }
-    try {
-      return `<pre><code class="hljs">${hljs.highlightAuto(str).value}</code></pre>`;
-    } catch { /* fallthrough */ }
-    return `<pre><code class="hljs">${escapeHtml(str)}</code></pre>`;
+    // 言語指定がない場合は自動判定に頼らず、そのままエスケープして出す。
+    // 誤判定した色付けは読み手を混乱させるうえ、Edge の CPU 時間も余計に使う。
+    return `<pre role="region" aria-label="コード"><code class="hljs">${escapeHtml(str)}</code></pre>`;
   },
 });
 md.use(anchor, { permalink: false, slugify: (s: string) => encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-')) });
@@ -46,9 +110,11 @@ function extractMetaContent(html: string, patterns: string[]): string | undefine
   return undefined;
 }
 
+// h3 まで拾う。以前は h1/h2 しか拾っておらず、目次コンポーネント側にある
+// h3 用のインデント分岐が一度も使われていなかった。
 function extractHeadings(html: string): { text: string; id: string; tag: string }[] {
   const headings: { text: string; id: string; tag: string }[] = [];
-  const regex = /<(h[12])[^>]*id=["']([^"']*)["'][^>]*>(.*?)<\/\1>/gi;
+  const regex = /<(h[123])[^>]*id=["']([^"']*)["'][^>]*>(.*?)<\/\1>/gi;
   let match;
   while ((match = regex.exec(html)) !== null) {
     headings.push({ tag: match[1], id: match[2], text: stripHtml(match[3]) });
@@ -81,10 +147,12 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { blogId } = await params;
-  const blog = await getDetail(blogId);
-
-  // optionally access and extend (rather than replace) parent metadata
-  const previousImages = blog.eyecatch || [];
+  // 記事が見つからない場合はここで例外を投げず、本体側の notFound() に任せる。
+  // catch がないと、存在しないURLが404ではなく500として扱われてしまう。
+  const blog = await getDetail(blogId).catch(() => null);
+  if (!blog) {
+    return { title: '記事が見つかりません', robots: { index: false, follow: false } };
+  }
 
   // markdown->平文（Edge互換）
   const cleanBody = blog.body
@@ -244,12 +312,6 @@ export default async function StaticDetailPage({
   processedHtml = processedHtml.replace(/<table/g, '<div class="table-scroll"><table');
   processedHtml = processedHtml.replace(/<\/table>/g, '</table></div>');
 
-  // コードブロックにaria-labelを付与
-  processedHtml = processedHtml.replace(
-    /<pre><code class="language-(\w+)"/g,
-    '<pre role="region" aria-label="$1 code"><code class="language-$1"'
-  );
-
   // 記事本文内画像に lazy loading + async decoding を付与
   processedHtml = processedHtml.replace(
     /<img(?![^>]*loading=)/g,
@@ -269,33 +331,39 @@ export default async function StaticDetailPage({
     '<li class="task-list-item">$1'
   );
 
-  // リンクカード生成（正規表現ベース）
-  const linkRegex = /<a[^>]*href="(https?:\/\/[^"]*)"[^>]*>.*?<\/a>/gi;
-  const uniqueLinks: string[] = [];
-  let linkMatch;
-  while ((linkMatch = linkRegex.exec(processedHtml)) !== null) {
-    const href = linkMatch[1];
-    if (!uniqueLinks.includes(href)) uniqueLinks.push(href);
-  }
+  // リンクカード化するのは <p> 内に単独で置かれたリンクだけ。
+  // 以前は本文中のインラインリンクも含めた全リンクにOGP取得をかけており、
+  // 大半の結果を捨てたうえで TTFB とWorkersのサブリクエスト数を消費していた。
+  const CARD_LINK_RE = /<p>\s*<a[^>]*href="(https?:\/\/[^"]*)"[^>]*>[^<]*<\/a>\s*<\/p>/gi;
+  const cardLinks = Array.from(
+    new Set(Array.from(processedHtml.matchAll(CARD_LINK_RE), (m) => m[1]))
+  );
 
-  const ogpResults = await Promise.allSettled(uniqueLinks.map(href => fetchOGPData(href)));
+  const ogpResults = await Promise.allSettled(cardLinks.map((href) => fetchOGPData(href)));
   const hrefToOgpData = new Map<string, any>();
-  uniqueLinks.forEach((href, i) => {
+  cardLinks.forEach((href, i) => {
     const result = ogpResults[i];
     hrefToOgpData.set(href, result.status === 'fulfilled' ? result.value : null);
   });
 
   // <p>タグ内の単独リンクをリンクカードに置換
-  processedHtml = processedHtml.replace(
-    /<p>\s*<a[^>]*href="(https?:\/\/[^"]*)"[^>]*>[^<]*<\/a>\s*<\/p>/gi,
-    (fullMatch, href) => {
-      const meta = hrefToOgpData.get(href);
-      const title = meta?.title || new URL(href).hostname;
-      const favicon = `https://www.google.com/s2/favicons?domain=${new URL(href).hostname}&sz=128`;
-      const image = meta?.image || favicon;
-      return `<div class="link-card mt-3 mb-3"><a href="${href}" target="_blank" rel="noopener noreferrer"><div class="link-card-body"><div class="link-card-info"><div class="link-card-title">${title}</div><div class="link-card-url">${href}</div></div><img src="${image}" class="link-card-thumbnail" /></div></a></div>`;
+  processedHtml = processedHtml.replace(CARD_LINK_RE, (_fullMatch, href: string) => {
+    const meta = hrefToOgpData.get(href);
+    let hostname: string;
+    try {
+      hostname = new URL(href).hostname;
+    } catch {
+      return _fullMatch;
     }
-  );
+    // 外部サイトから取ってきた値なので必ずエスケープする
+    const title = escapeHtml(meta?.title || hostname);
+    const safeHref = escapeHtml(href);
+    const favicon = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostname)}&sz=128`;
+    const thumbnail = meta?.image
+      ? `<img src="${escapeHtml(meta.image)}" alt="" class="link-card-thumbnail" loading="lazy" />`
+      : '';
+    return `<div class="link-card${thumbnail ? '' : ' link-card--no-image'}"><a href="${safeHref}" target="_blank" rel="noopener noreferrer"><div class="link-card-body"><div class="link-card-info"><div class="link-card-title">${title}</div><div class="link-card-url"><img src="${favicon}" alt="" class="link-card-favicon" loading="lazy" />${escapeHtml(hostname)}</div></div>${thumbnail}</div></a></div>`;
+  });
 
   // 目次生成（正規表現ベース）
   const toc = extractHeadings(processedHtml);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -305,26 +305,44 @@ body {
   right: 0;
 }
 
+/* 0.3px はサブピクセルで端末により消える/濃く出るうえ、
+   枠色に本文色をそのまま使っていたため記事の中で必要以上に主張していた。 */
 .link-card {
   -webkit-box-align: center;
-  border: 0.3px solid rgb(var(--foreground-rgb)) !important;
+  border: 1px solid rgb(226 232 240);
   border-radius: 8px;
   display: flex;
-  -webkit-box-pack: justify;
   justify-content: space-between;
   overflow: hidden;
   text-decoration: none;
   overflow-wrap: anywhere;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  margin: 1.5rem 0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: box-shadow 0.2s, border-color 0.2s, transform 0.2s;
+}
+.dark .link-card {
+  border-color: rgb(51 65 85);
 }
 
 .link-card > a {
   color: rgb(var(--foreground-rgb)) !important;
   width: 100%;
+  text-decoration: none !important;
 }
 
 .link-card:hover {
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  border-color: rgb(148 163 184);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+}
+
+.link-card-favicon {
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  vertical-align: -2px;
+  margin-right: 0.4em;
+  border-radius: 2px;
 }
 
 .link-card-body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -131,6 +131,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel='preconnect' href='https://pub-9d03846db4364486bb0806774184931a.r2.dev' crossOrigin='anonymous' />
         <link rel='dns-prefetch' href='https://www.googletagmanager.com' />
         <link rel='dns-prefetch' href='https://www.google.com' />
+        {/* JS無効時、スクロール連動で表示する要素が非表示のままにならないようにする */}
+        <noscript>
+          <style>{'.fade-in-pending{opacity:1!important;transform:none!important}'}</style>
+        </noscript>
       </head>
       <body>
         <ThemeProvider

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,8 +96,9 @@ export default async function StaticPage() {
                 <div className='relative aspect-[16/9] lg:aspect-auto lg:h-full lg:min-h-[420px] rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-800'>
                   <Image
                     src={latestBlogs[0].eyecatch?.url || '/images/no_image_generated.png'}
-                    alt={latestBlogs[0].title}
+                    alt=''
                     fill
+                    sizes='(max-width: 1024px) 100vw, 600px'
                     className='object-cover group-hover:scale-105 transition-transform duration-500'
                     priority
                   />
@@ -126,8 +127,9 @@ export default async function StaticPage() {
                   <div className='relative h-full aspect-[16/9] lg:aspect-auto lg:min-h-0 rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-800'>
                     <Image
                       src={blog.eyecatch?.url || '/images/no_image_generated.png'}
-                      alt={blog.title}
+                      alt=''
                       fill
+                      sizes='(max-width: 1024px) 100vw, 600px'
                       className='object-cover group-hover:scale-105 transition-transform duration-500'
                     />
                     <div className='absolute inset-0 bg-gradient-to-t from-black/90 via-black/40 to-black/10' />

--- a/src/app/searches/client_index.tsx
+++ b/src/app/searches/client_index.tsx
@@ -109,8 +109,9 @@ export const ClientIndex = ({ contents }: BlogProps) => {
                     <div className='flex-shrink-0 relative w-24 sm:w-32 h-full rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-700'>
                       <Image
                         src={blog.eyecatch?.url || '/images/no_image_generated.png'}
-                        alt={blog.title}
+                        alt=''
                         fill
+                        sizes='(max-width: 640px) 96px, 128px'
                         className='object-cover group-hover:scale-105 transition-transform duration-300'
                       />
                       {Date.now() - new Date(blog.createdAt).getTime() < 72 * 60 * 60 * 1000 && (

--- a/src/components/FadeIn/FadeIn.tsx
+++ b/src/components/FadeIn/FadeIn.tsx
@@ -9,23 +9,38 @@ export const FadeIn = ({ children, className = '' }: { children: React.ReactNode
     const el = ref.current;
     if (!el) return;
 
+    // IntersectionObserver が使えない環境では、そのまま表示する
+    if (typeof IntersectionObserver === 'undefined') {
+      setHasAnimated(true);
+      return;
+    }
+
     const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting && !hasAnimated) {
+      ([entry], obs) => {
+        if (entry.isIntersecting) {
           setHasAnimated(true);
+          // 一度表示したら監視は不要
+          obs.disconnect();
         }
       },
       { threshold: 0.05 }
     );
     observer.observe(el);
-    return () => observer.disconnect();
-  }, [hasAnimated]);
+    // Observerが何らかの理由で発火しなくても、記事一覧が消えたままにならないようにする
+    const fallback = setTimeout(() => setHasAnimated(true), 1500);
+    return () => {
+      observer.disconnect();
+      clearTimeout(fallback);
+    };
+    // 依存に hasAnimated を入れると、表示のたびに Observer を作り直すことになる
+  }, []);
 
   return (
     <div
       ref={ref}
+      // fade-in-pending は JS 無効時に globals.css 側で強制表示するためのフック
       className={`transition-all duration-500 ${
-        hasAnimated ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3'
+        hasAnimated ? 'opacity-100 translate-y-0' : 'fade-in-pending opacity-0 translate-y-3'
       } ${className}`}
       style={{ willChange: hasAnimated ? 'auto' : 'opacity, transform' }}
     >

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Link from 'next/link';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ModeToggle } from '../ModeToggle/modeToggle';
 import { Menu, X, Home, BookOpen, User, Search, Github } from 'lucide-react';
 import { SearchModal } from '../SearchModal/SearchModal';
@@ -9,7 +9,9 @@ export const Header = () => {
   const [isOpen, setOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState<string>('Home');
   const [hidden, setHidden] = useState(false);
-  const [lastY, setLastY] = useState(0);
+  // 直前のスクロール位置は state にしない。
+  // state にすると更新のたびに再レンダーが走り、下の useEffect がリスナーを張り直してしまう。
+  const lastY = useRef(0);
 
   useEffect(() => {
     if (isOpen) {
@@ -22,19 +24,22 @@ export const Header = () => {
     };
   }, [isOpen]);
 
+  // 依存配列がないと毎レンダーでリスナーを付け外しすることになる
   useEffect(() => {
+    let ticking = false;
     const handleScroll = () => {
-      const y = window.scrollY;
-      if (y > 100 && y > lastY) {
-        setHidden(true);
-      } else {
-        setHidden(false);
-      }
-      setLastY(y);
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        const y = window.scrollY;
+        setHidden(y > 100 && y > lastY.current);
+        lastY.current = y;
+        ticking = false;
+      });
     };
     window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
-  });
+  }, []);
 
   const handleMenuClose = (menuName: string) => {
     setOpen(false);

--- a/src/components/Index/Index.tsx
+++ b/src/components/Index/Index.tsx
@@ -28,8 +28,10 @@ export const Index = ({ contents }: BlogProps) => {
                 <div className='flex-shrink-0 relative w-24 sm:w-32 h-full rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-700'>
                   <Image
                     src={blog.eyecatch?.url || '/images/no_image_generated.png'}
-                    alt={blog.title}
+                    alt=''
                     fill
+                    // 実表示は96〜128px。sizes がないと 100vw 扱いになり原寸が配信される
+                    sizes='(max-width: 640px) 96px, 128px'
                     className='object-cover group-hover:scale-105 transition-transform duration-300'
                   />
                   {Date.now() - new Date(blog.createdAt).getTime() < 72 * 60 * 60 * 1000 ? (

--- a/src/components/RelatedPosts/RelatedPosts.tsx
+++ b/src/components/RelatedPosts/RelatedPosts.tsx
@@ -37,8 +37,9 @@ export const RelatedPosts = ({ posts, currentPostId }: RelatedPostsProps) => {
               <div className='relative aspect-[16/9] mb-3 rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-800'>
                 <Image
                   src={post.eyecatch?.url || '/images/no_image_generated.png'}
-                  alt={post.title}
+                  alt=''
                   fill
+                  sizes='(max-width: 640px) 100vw, 250px'
                   className='object-cover group-hover:scale-105 transition-transform duration-300'
                 />
                 {post.category && (

--- a/src/components/TableOfContents/StickyTableOfContents.tsx
+++ b/src/components/TableOfContents/StickyTableOfContents.tsx
@@ -12,43 +12,38 @@ interface TocItem {
 
 export const StickyTableOfContents = ({ toc }: { toc: TocItem[] }) => {
   const [activeId, setActiveId] = useState<string>('');
-  const [scrollProgress, setScrollProgress] = useState(0);
   const tocRef = useRef<HTMLUListElement>(null);
   const activeItemRef = useRef<HTMLLIElement>(null);
 
+  // 以前はスクロールイベントごとに getElementById と offsetTop を見出しの数だけ実行していた。
+  // offsetTop / scrollHeight の読み取りは強制同期レイアウトを起こすため、
+  // スクロール中に毎フレーム走るとジャンクの原因になる。
   useEffect(() => {
-    const handleScroll = () => {
-      const headings = toc.map((item) => document.getElementById(item.id));
-      const scrollPosition = window.scrollY + 100;
+    if (toc.length === 0 || typeof IntersectionObserver === 'undefined') return;
 
-      // 現在表示されているセクションを特定
-      let currentActiveId = '';
-      for (let i = headings.length - 1; i >= 0; i--) {
-        const heading = headings[i];
-        if (heading && heading.offsetTop <= scrollPosition) {
-          currentActiveId = toc[i].id;
-          break;
-        }
-      }
+    const elements = toc
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
 
-      // 最初のセクションより上にいる場合は最初のセクションをアクティブに
-      if (!currentActiveId && headings[0]) {
-        currentActiveId = toc[0].id;
-      }
+    const visible = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) visible.add(entry.target.id);
+          else visible.delete(entry.target.id);
+        });
+        // 目次の並び順で最初に見えているものを現在地とする
+        const current = toc.find((item) => visible.has(item.id));
+        if (current) setActiveId(current.id);
+      },
+      // ヘッダー分を除いた画面上部30%に入った見出しを「現在地」とみなす
+      { rootMargin: '-80px 0px -70% 0px', threshold: 0 }
+    );
 
-      setActiveId(currentActiveId);
-
-      // スクロール進捗の計算
-      const winScroll = document.body.scrollTop || document.documentElement.scrollTop;
-      const height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-      const scrolled = (winScroll / height) * 100;
-      setScrollProgress(scrolled);
-    };
-
-    window.addEventListener('scroll', handleScroll);
-    handleScroll();
-
-    return () => window.removeEventListener('scroll', handleScroll);
+    elements.forEach((el) => observer.observe(el));
+    setActiveId(toc[0].id);
+    return () => observer.disconnect();
   }, [toc]);
 
   // アクティブなアイテムが変更されたときに目次内でスクロール
@@ -73,27 +68,16 @@ export const StickyTableOfContents = ({ toc }: { toc: TocItem[] }) => {
     }
   }, [activeId]);
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
-    e.preventDefault();
-    const element = document.getElementById(id);
-    if (element) {
-      const offset = 80; // ヘッダーの高さ分のオフセット
-      const elementPosition = element.offsetTop - offset;
-      
-      window.scrollTo({
-        top: elementPosition,
-        behavior: 'smooth'
-      });
-      
-      // URLを更新
-      window.history.pushState(null, '', `#${id}`);
-      setActiveId(id);
-    }
-  };
+  // preventDefault + pushState をやめ、ブラウザ標準のアンカー移動に任せる。
+  // 以前は目次を押すたびに履歴が積まれ、戻るボタンで前のページに帰れなくなっていた。
+  // ヘッダー分のオフセットは globals.css の scroll-padding-top が担当する。
+  const handleClick = (id: string) => setActiveId(id);
+
+  if (toc.length === 0) return null;
 
   return (
-    <div className='sticky top-20 p-4 rounded-lg bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm'>
-      <h2 className='text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-4'>
+    <nav aria-label='目次' className='sticky top-20 p-4 rounded-lg bg-white/50 dark:bg-slate-900/50 backdrop-blur-sm'>
+      <h2 className='text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-4'>
         目次
       </h2>
 
@@ -111,11 +95,13 @@ export const StickyTableOfContents = ({ toc }: { toc: TocItem[] }) => {
           >
             <a
               href={`#${item.id}`}
-              onClick={(e) => handleClick(e, item.id)}
-              className={`block text-sm py-1.5 pl-3 transition-colors ${
+              onClick={() => handleClick(item.id)}
+              title={item.text}
+              // 長い見出しで目次が縦に伸びすぎないよう2行までにする
+              className={`block text-sm py-1.5 pl-3 line-clamp-2 transition-colors ${
                 activeId === item.id
                   ? 'text-blue-600 dark:text-blue-400 font-medium'
-                  : 'text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
+                  : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
               }`}
             >
               {item.text}
@@ -123,6 +109,6 @@ export const StickyTableOfContents = ({ toc }: { toc: TocItem[] }) => {
           </li>
         ))}
       </ul>
-    </div>
+    </nav>
   );
 };

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -210,11 +210,15 @@
   background-color: #0b1220 !important;
 }
 
-/* Code language label */
-.znc pre:has(code[class*="language-"]) {
+/* Code language label
+   ラベルはサーバー側で data-lang として埋める。
+   以前は :has() と言語ごとのハードコードに頼っていたため、
+   未対応言語ではラベルが空のまま余白だけ空き、Firefox 121未満では
+   :has() が効かずラベルがコードに重なっていた。 */
+.znc pre.has-lang {
   padding-top: 2em;
 }
-.znc pre code[class*="language-"]::before {
+.znc pre code[data-lang]::before {
   content: attr(data-lang);
   position: absolute;
   top: 8px;
@@ -222,23 +226,8 @@
   font-size: 11px;
   font-family: -apple-system, sans-serif;
   color: #94a3b8;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.znc pre code.language-typescript::before { content: 'TypeScript'; }
-.znc pre code.language-javascript::before { content: 'JavaScript'; }
-.znc pre code.language-bash::before { content: 'Bash'; }
-.znc pre code.language-css::before { content: 'CSS'; }
-.znc pre code.language-html::before { content: 'HTML'; }
-.znc pre code.language-json::before { content: 'JSON'; }
-.znc pre code.language-yaml::before { content: 'YAML'; }
-.znc pre code.language-toml::before { content: 'TOML'; }
-.znc pre code.language-python::before { content: 'Python'; }
-.znc pre code.language-ruby::before { content: 'Ruby'; }
-.znc pre code.language-go::before { content: 'Go'; }
-.znc pre code.language-sql::before { content: 'SQL'; }
-.znc pre code.language-tsx::before { content: 'TSX'; }
-.znc pre code.language-jsx::before { content: 'JSX'; }
 
 /* Code copy button */
 .znc pre .copy-btn {


### PR DESCRIPTION
## What

記事1本を表示するのに Edge でもブラウザでも余計な仕事をしていたので、まとめて削減しました。

Closes #340, #372, #379(一部), #391, #392, #393, #394, #396, #397, #398, #433, #446, #449(一部), #466, #467, #476, #480, #481, #484, #485

## Why / How

### Notion API の往復

| 問題 | 対応 |
|---|---|
| `getDetail` が `generateMetadata` と本体で**2回**呼ばれ、記事のブロック展開も2回走っていた | `cache()` でリクエスト内メモ化 |
| `getTagList` / `getCategoryList` / それぞれの `*Detail` が**個別にDBスキーマを取得**。カテゴリページ1枚で同じスキーマを4回取りに行っていた | スキーマ取得を共通化してメモ化 |
| `getList` がモジュールスコープの変数に結果を保持 | 削除 |

**`listCache` は実害のあるリスクでした。** Cloudflare Workers の isolate はリクエスト間で再利用されるため、生きている isolate では古い一覧が返り続けます。#329 で対処した「新記事が即時反映されない」問題が、この経路で再発しうる状態でした。鮮度は CDN の `Cache-Control` が担当するので、アプリ側で持つ必要はありません。

また `generateMetadata` の `getDetail` に catch がなく、**存在しないURLが404ではなく500**になっていました（本体側の `notFound()` に到達する前に例外が飛ぶため）。

### バンドルサイズ

`highlight.js` を既定エントリ（190以上の言語定義）から `lib/core` + 実使用言語のみに変更。**実測しました。**

| | before | after |
|---|---|---|
| `.next/server/app/blogs/[blogId]/page.js` | **1.1M** | **260K** |
| `.next/server/app/blogs/` 全体 | 4.7M | 2.3M |

あわせて `highlightAuto` を廃止。言語指定のないブロックに対して登録済み全文法を試すため、Worker の CPU 時間を使って「推測」を出していました。指定がない場合はエスケープのみにしています。

### リクエスト数

OGP 取得を**リンクカード化の対象（`<p>` 内の単独リンク）だけ**に限定。以前は本文中のインラインリンクも含めた全リンクに 1.5秒タイムアウトの fetch をかけ、大半の結果を捨てていました（Workers のサブリクエスト上限にも効きます）。

あわせてリンクカードのセキュリティも修正しています。**タイトルは外部サイトの `og:title` をそのままHTMLに埋め込んでいた**ため、悪意ある `og:title` を持つサイトへのリンクで任意のHTMLが注入できる状態でした。エスケープとスキーム検証を追加し、OGP画像がない場合は128pxのfaviconを200px幅に引き伸ばすのをやめてコンパクトなカードにしています。

### ブラウザ側

- **Header**: `useEffect` に依存配列がなく、`setLastY` の再レンダーのたびにスクロールリスナーを付け外ししていた → `useRef` + `requestAnimationFrame`
- **Sticky目次**: スクロールイベントごとに見出しの数だけ `offsetTop` を読んでおり、**毎フレーム強制同期レイアウト**が発生 → `IntersectionObserver`
- **目次クリック**: `pushState` で履歴が積まれ、**戻るボタンで記事から出られなくなっていた** → ブラウザ標準のアンカー移動 + `scroll-padding-top`
- **FadeIn**: Observer が表示のたびに作り直され、発火しないと `opacity-0` のまま。初回で `disconnect`、タイムアウトのフォールバック、`<noscript>` で強制表示

### その他

- `next/image` の `sizes` が**リポジトリ全体で0件**だった。128pxのサムネイルに原寸画像が配信されていたので実表示幅を指定
- コードの言語ラベルが `attr(data-lang)` を参照していたが**`data-lang` はどこでも付与されておらず**、未対応言語では空ラベルの上に2emの余白だけが空いていた。さらに `:has()` 依存で Firefox 121未満では効かない。サーバー側で出力するよう変更
- `typographer: true` が `...` を `…`、`--` を `–`、`"` を `"` に変換していた。**コマンドやJSONが壊れる**ので無効化
- `extractHeadings` が h1/h2 しか拾わず、目次3コンポーネントの h3 分岐が全部デッドコードだった

## Testing

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx next build` — Compiled successfully
- [x] `npm run lint` — 新規warningなし
- [x] バンドルサイズを before/after で実測（上表）
- [x] highlight.js の言語登録・別名解決・ラベルをスクリプトで検証

検証中に、ラベル解決を `hljs.getLanguage().name` に頼っていたのが脆い（`"HTML, XML"` のような文字列が返る）と分かったため、別名を含む辞書引きに単純化しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_