### PR TITLE
fix: XのアカウントURL・ハンドルを @tech_koki に更新する

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ public/           # 静的ファイル, manifest.json, llms.txt
 
 ## Author
 
-**Koki** - [@meow_koki](https://x.com/meow_koki) - [GitHub](https://github.com/j19015)
+**Koki** - [@tech_koki](https://x.com/tech_koki) - [GitHub](https://github.com/j19015)

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -2,7 +2,7 @@
 Developer: Koki
 Site: https://kt-tech.blog
 GitHub: https://github.com/j19015
-X: https://x.com/meow_koki
+X: https://x.com/tech_koki
 
 /* SITE */
 Standards: HTML5, CSS3, JavaScript

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -25,4 +25,4 @@ kt-tech.blog はフルスタックエンジニア Koki が運営する技術ブ�
 
 ## Contact
 - GitHub: https://github.com/j19015
-- X (Twitter): https://x.com/meow_koki
+- X (Twitter): https://x.com/tech_koki

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -181,7 +181,7 @@ export default function About() {
               <Github className='w-5 h-5' />
             </Link>
             <Link
-              href='https://x.com/meow_koki'
+              href='https://x.com/tech_koki'
               target='_blank'
               rel='noopener noreferrer'
               className='text-slate-500 dark:text-slate-400'
@@ -360,7 +360,7 @@ export default function About() {
           <p className='text-sm text-slate-600 dark:text-slate-300'>
             ご興味を持っていただけた方は、
             <Link
-              href='https://x.com/meow_koki'
+              href='https://x.com/tech_koki'
               target='_blank'
               rel='noopener noreferrer'
               className='text-slate-700 dark:text-slate-300 underline mx-1'

--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -177,8 +177,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       card: 'summary_large_image' as const,
       title: blog.title,
       description,
-      site: '@meow_koki',
-      creator: '@meow_koki',
+      site: '@tech_koki',
+      creator: '@tech_koki',
       ...(ogImage ? { images: [ogImage] } : {}),
     },
     openGraph: {
@@ -388,7 +388,7 @@ export default async function StaticDetailPage({
       url: 'https://kt-tech.blog/about',
       sameAs: [
         'https://github.com/j19015',
-        'https://x.com/meow_koki',
+        'https://x.com/tech_koki',
       ],
     },
     publisher: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,8 +56,8 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: `${siteName} - 技術と創造性が交わる場所`,
     description,
-    site: '@meow_koki',
-    creator: '@meow_koki',
+    site: '@tech_koki',
+    creator: '@tech_koki',
   },
   robots: {
     index: true,
@@ -96,7 +96,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       name: author,
       url: 'https://github.com/j19015',
       sameAs: [
-        'https://x.com/meow_koki',
+        'https://x.com/tech_koki',
         'https://github.com/j19015'
       ]
     },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,8 +28,8 @@ export const metadata = {
     card: 'summary_large_image',
     title: 'kt-tech.blog - 技術と創造性が交わる場所',
     description,
-    site: '@meow_koki',
-    creator: '@meow_koki',
+    site: '@tech_koki',
+    creator: '@tech_koki',
   },
 };
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -40,7 +40,7 @@ export const Footer = () => {
                 <Github className='w-5 h-5' />
               </Link>
               <Link
-                href='https://x.com/meow_koki'
+                href='https://x.com/tech_koki'
                 target='_blank'
                 rel='noopener noreferrer'
                 className='text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:scale-110 transition-all duration-200'

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -155,7 +155,7 @@ export const Header = () => {
                 <a href='https://github.com/j19015' target='_blank' rel='noopener noreferrer' className='text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors'>
                   <Github className='w-5 h-5' />
                 </a>
-                <a href='https://x.com/meow_koki' target='_blank' rel='noopener noreferrer' className='text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors'>
+                <a href='https://x.com/tech_koki' target='_blank' rel='noopener noreferrer' className='text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors'>
                   <svg className='w-5 h-5' viewBox='0 0 24 24' fill='currentColor'><path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z' /></svg>
                 </a>
               </div>

--- a/src/components/Modal/contactModal.tsx
+++ b/src/components/Modal/contactModal.tsx
@@ -38,7 +38,7 @@ const ContactModal = ({ isOpen, onClose }: ContactModalProps) => {
 
             <div className='space-y-3'>
               <Link
-                href='https://x.com/meow_koki'
+                href='https://x.com/tech_koki'
                 target='_blank'
                 rel='noopener noreferrer'
                 className='flex items-center gap-3 px-4 py-3 rounded-md border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors'
@@ -46,7 +46,7 @@ const ContactModal = ({ isOpen, onClose }: ContactModalProps) => {
                 <XIcon className='w-5 h-5 text-slate-700 dark:text-slate-300' />
                 <div>
                   <p className='text-sm font-medium text-slate-800 dark:text-slate-200'>X (Twitter)</p>
-                  <p className='text-xs text-slate-500'>@meow_koki</p>
+                  <p className='text-xs text-slate-500'>@tech_koki</p>
                 </div>
               </Link>
 


### PR DESCRIPTION
## What

XのURLとハンドルが古い `meow_koki` のままだったので、`tech_koki` に統一しました。

## Why

アカウントが変わっているため、サイト内のXリンクが全てリンク切れになっていました。プロフィールリンクだけでなく、**OGP/Twitterカードのメタデータや構造化データにも埋まっている**ため、SNSでシェアされたときの表示や検索エンジンの著者情報にも影響します。

## How

置換対象は以下の3種類です。

**1. プロフィールリンク**
- `src/components/Header/Header.tsx`（モバイルメニュー）
- `src/components/Footer/Footer.tsx`
- `src/components/Modal/contactModal.tsx`（リンク + 表示テキストの `@meow_koki`）
- `src/app/about/page.tsx`（プロフィール欄・お仕事のご依頼欄）

**2. メタデータ / 構造化データ**
- `twitter.site` / `twitter.creator` … `src/app/layout.tsx`, `src/app/page.tsx`, `src/app/blogs/[blogId]/page.tsx`
- JSON-LD の `author.sameAs` … `src/app/layout.tsx`, `src/app/blogs/[blogId]/page.tsx`

**3. 静的ファイル**
- `public/humans.txt`
- `public/llms.txt`（AI検索向けのプロフィール情報）
- `README.md`

### 触っていないもの

`public/images/meow_koki.webp` はローカルの画像ファイル名でXのハンドルとは無関係なので、そのままにしています。ファイル名も揃えたい場合は別途対応します（3箇所から参照されています）。

## Testing

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx next build` — Compiled successfully
- [x] `grep` で `meow_koki` の残存が画像ファイル名の3箇所のみであることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_