### PR TITLE
feat: Callout に種別を持たせ、記事はタイトルから始まるようにする

### DIFF
--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -2,8 +2,6 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { getDetail, getList, Blog } from '../../../../libs/notion';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCalendarAlt, faTag } from '@fortawesome/free-solid-svg-icons';
 import MarkdownIt from 'markdown-it';
 import anchor from 'markdown-it-anchor';
 import hljs from 'highlight.js/lib/core';
@@ -122,7 +120,6 @@ function extractHeadings(html: string): { text: string; id: string; tag: string 
   return headings;
 }
 import type { Metadata, ResolvingMetadata } from 'next';
-import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import { TableOfContents } from '@/components/TableOfContents/TableOfContents';
 import { StickyTableOfContents } from '@/components/TableOfContents/StickyTableOfContents';
 import { RelatedPosts } from '@/components/RelatedPosts/RelatedPosts';
@@ -137,6 +134,9 @@ import { KeyboardNav } from '@/components/KeyboardNav/KeyboardNav';
 import { FloatingTocButton } from '@/components/TableOfContents/FloatingTocButton';
 import { BookmarkButton } from '@/components/Bookmark/BookmarkButton';
 import { isPublic } from '@/lib/blog';
+import { calloutKindFromColor, CALLOUT_META } from '@/lib/callout';
+// カレンダー・フォルダの3アイコンのために FontAwesome 一式を読み込んでいたので lucide に統一
+import { Calendar, FolderOpen, Pencil, MessageCircle } from 'lucide-react';
 
 
 export const runtime = 'edge';
@@ -285,7 +285,15 @@ export default async function StaticDetailPage({
     const isSingleParagraph =
       /^<p>[\s\S]*<\/p>$/.test(rendered) && !rendered.slice(3, -4).includes('<p>');
     const textHtml = isSingleParagraph ? rendered.slice(3, -4) : rendered;
-    const calloutHtml = `<div class="callout callout-${color}"><span class="callout-icon" aria-hidden="true">${icon}</span><div class="callout-content">${textHtml}</div></div>`;
+    // 色ではなく「意味」でクラスを付け、種別ラベルを添える。
+    // 色だけでは何の注意書きなのかが伝わらない。
+    const kind = calloutKindFromColor(color);
+    const meta = CALLOUT_META[kind];
+    const calloutHtml =
+      `<div class="callout callout--${kind}">` +
+      `<div class="callout__label"><span class="callout__icon" aria-hidden="true">${icon || meta.icon}</span>${meta.label}</div>` +
+      `<div class="callout__body">${textHtml}</div>` +
+      `</div>`;
     // 置換文字列を関数で渡し、本文中の $& などが置換パターンとして解釈されるのを防ぐ
     processedHtml = processedHtml.replace(
       new RegExp(`<p>${placeholder}</p>|${placeholder}`, 'g'),
@@ -372,6 +380,10 @@ export default async function StaticDetailPage({
     notFound();
   }
 
+  // 読了時間は本文・JSON-LDで同じ値を使う
+  const plainText = stripHtml(processedHtml);
+  const readingMinutes = Math.max(1, Math.ceil(plainText.length / 600));
+
   // JSON-LD 構造化データ
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -407,8 +419,8 @@ export default async function StaticDetailPage({
       '@type': 'SpeakableSpecification',
       cssSelector: ['[data-article-title]', '[data-article-description]'],
     },
-    wordCount: stripHtml(processedHtml).length,
-    timeRequired: `PT${Math.max(1, Math.ceil(stripHtml(processedHtml).length / 600))}M`,
+    wordCount: plainText.length,
+    timeRequired: `PT${readingMinutes}M`,
   };
 
   const breadcrumbJsonLd = {
@@ -431,76 +443,65 @@ export default async function StaticDetailPage({
           { label: blog.title, current: true }
         ]}
       />
-      <div className='grid grid-cols-1 lg:grid-cols-3 lg:p-4'>
-        <div className='lg:col-span-1 p-5 pl-7 pt-0 hidden lg:block'>
-          <StickyTableOfContents toc={toc} />
-        </div>
-        {/* overflow: hidden はスクロールコンテナを作り、scroll-padding-top や
-            将来の sticky 要素に影響する。横のはみ出しだけを止めれば足りる。 */}
-        <div className='lg:col-span-2 col-span-1 lg:py-5 lg:px-3 content [overflow-x:clip]'>
+      {/* 本文を先に置き、目次は order で右に回す。
+          DOM順を本文優先にすることで、スクリーンリーダーと検索エンジンにも本文が先に届く。
+          左に目次があると本文の開始位置が右にずれ、視線の起点が補助情報になっていた。 */}
+      <div className='max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-3 gap-6 lg:p-4'>
+        <div className='lg:col-span-2 lg:order-1 content [overflow-x:clip]'>
           {/* 記事本文はランドマークとして辿れるよう article にする */}
           <article>
-            <div className='p-4'>
-              <Image
-                src={blog.eyecatch?.url || '/images/no_image_generated.png'}
-                alt={blog.title}
-                width={1200}
-                height={630}
-                className='rounded-lg w-full'
-                priority
-              />
-            </div>
-            {/* メタデータセクション */}
-            <div className='p-6 space-y-4'>
-              {/* カテゴリと日付と読了時間 */}
-              <div className='flex flex-wrap items-center gap-3'>
+            {/* タイトル → メタ → 本文 の順にする。
+                以前はアイキャッチとメタ情報が先で、記事を開いた瞬間に
+                何の記事か分かるまでスクロールが必要だった。 */}
+            <header className='px-4'>
+              <h1 data-article-title className='text-2xl lg:text-3xl font-bold text-foreground break-words leading-tight'>
+                {blog.title}
+              </h1>
+
+              <div className='mt-4 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm'>
                 {blog.category && (
-                  <Link href={`/categories/${blog.category.id}/page/1`}>
-                    <span className='inline-flex items-center gap-2 px-3 py-1.5 bg-slate-100 dark:bg-slate-800 rounded-full text-sm font-medium text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors'>
-                      <FontAwesomeIcon icon={faFolderOpen} className='w-3.5 h-3.5' />
-                      {blog.category.name}
-                    </span>
+                  <Link
+                    href={`/categories/${blog.category.id}/page/1`}
+                    className='inline-flex items-center gap-1.5 px-2.5 py-1 bg-slate-100 dark:bg-slate-800 rounded-full text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors'
+                  >
+                    <FolderOpen className='w-3.5 h-3.5' aria-hidden='true' />
+                    {blog.category.name}
                   </Link>
                 )}
-                <div className='flex items-center gap-2 text-muted-foreground'>
-                  <FontAwesomeIcon icon={faCalendarAlt} className='w-4 h-4' />
-                  <time className='text-sm' dateTime={blog.createdAt}>
+                <span className='inline-flex items-center gap-1.5 text-slate-500 dark:text-slate-400'>
+                  <Calendar className='w-3.5 h-3.5' aria-hidden='true' />
+                  <time dateTime={blog.createdAt}>
                     {new Date(blog.createdAt).toLocaleDateString('ja-JP', {
                       year: 'numeric',
                       month: 'long',
-                      day: 'numeric'
+                      day: 'numeric',
                     })}
                   </time>
-                </div>
+                </span>
                 {blog.updatedAt !== blog.createdAt && (
-                  <time className='text-xs text-slate-500 dark:text-slate-400' dateTime={blog.updatedAt}>
-                    最終更新: {new Date(blog.updatedAt).toLocaleDateString('ja-JP')}
+                  <time className='text-slate-500 dark:text-slate-400' dateTime={blog.updatedAt}>
+                    最終更新 {new Date(blog.updatedAt).toLocaleDateString('ja-JP')}
                   </time>
                 )}
-                <span className='text-xs text-slate-500 dark:text-slate-500'>
-                  · 約{Math.max(1, Math.ceil(stripHtml(processedHtml).length / 600))}分で読めます
-                </span>
+                <span className='text-slate-500 dark:text-slate-400'>約{readingMinutes}分で読めます</span>
               </div>
-              
-              {/* タグ */}
-              {blog.tags && blog.tags.length > 0 && (
-                <div className='flex flex-wrap gap-2'>
-                  {blog.tags.map((tag) => (
-                    <Link key={tag.id} href={`/tags/${tag.id}`}>
-                      <span className='inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 rounded-full text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors'>
-                        <FontAwesomeIcon icon={faTag} className='w-3 h-3' />
-                        {tag.name}
-                      </span>
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
-            <h1 data-article-title className='p-4 mt-5 text-xl font-bold lg:text-3xl text-foreground break-words'>{blog.title}</h1>
-            <ShareButtons title={blog.title} url={`${process.env.SITE_URL}/blogs/${blog.id}`} />
-            <div className='px-6 -mt-4 mb-4'>
-              <BookmarkButton articleId={blogId} title={blog.title} />
-            </div>
+
+              <div className='mt-4'>
+                <BookmarkButton articleId={blogId} title={blog.title} />
+              </div>
+
+              {/* アイキャッチは自動生成の抽象画像で内容を説明しないため、
+                  高さを抑えて本文までの距離を縮める */}
+              <Image
+                src={blog.eyecatch?.url || '/images/no_image_generated.png'}
+                alt=''
+                width={1200}
+                height={630}
+                sizes='(max-width: 1024px) 100vw, 700px'
+                className='mt-6 rounded-lg w-full aspect-[21/9] object-cover'
+                priority
+              />
+            </header>
             <TableOfContents toc={toc} />
             <div className='p-4 znc markdown text-foreground'>
               <div dangerouslySetInnerHTML={{ __html: processedHtml }}></div>
@@ -508,38 +509,72 @@ export default async function StaticDetailPage({
               <ImageLightbox />
               <ReadingTracker articleId={blogId} />
             </div>
-            {/* 記事末シェアCTA + 著者カード */}
-            <div className='mt-12 mx-4 p-6 bg-slate-50 dark:bg-slate-800/50 rounded-lg space-y-6'>
+            {/* 記事末: タグ → シェア/著者/フィードバック → 前後記事 → 関連記事。
+                以前はシェアが記事上部と末尾の2箇所にあり、著者カードもリンク先がなかった。 */}
+            {blog.tags && blog.tags.length > 0 && (
+              <div className='mt-12 mx-4'>
+                <h2 className='text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-3'>
+                  この記事のタグ
+                </h2>
+                <div className='flex flex-wrap gap-2'>
+                  {blog.tags.map((tag) => (
+                    <Link
+                      key={tag.id}
+                      href={`/tags/${tag.id}`}
+                      className='inline-flex items-center px-3 py-1.5 bg-slate-100 dark:bg-slate-800 rounded-full text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors'
+                    >
+                      #{tag.name}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className='mt-8 mx-4 p-6 bg-slate-50 dark:bg-slate-800/50 rounded-lg space-y-6'>
               <div className='text-center'>
-                <p className='text-sm text-slate-600 dark:text-slate-400 mb-3'>この記事が役に立ったら共有しよう</p>
+                <p className='text-sm text-slate-600 dark:text-slate-300 mb-3'>この記事が役に立ったら共有しよう</p>
                 <ShareButtons title={blog.title} url={`${process.env.SITE_URL}/blogs/${blog.id}`} />
               </div>
               <div className='border-t border-slate-200 dark:border-slate-700 pt-6'>
-                <div className='flex items-center gap-4'>
-                  <img src='/images/meow_koki.webp' alt='Koki' className='w-12 h-12 rounded-full object-cover' />
+                {/* 著者カードはどこにもリンクしておらず、行き止まりになっていた */}
+                <Link href='/about' className='group flex items-center gap-4'>
+                  <Image
+                    src='/images/meow_koki.webp'
+                    alt=''
+                    width={48}
+                    height={48}
+                    className='rounded-full object-cover'
+                  />
                   <div>
-                    <p className='font-bold text-slate-900 dark:text-slate-100'>Koki</p>
-                    <p className='text-xs text-slate-500 dark:text-slate-400'>フルスタックエンジニア / React, Next.js, TypeScript</p>
+                    <p className='font-bold text-slate-900 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors'>
+                      Koki
+                    </p>
+                    <p className='text-xs text-slate-500 dark:text-slate-400'>
+                      フルスタックエンジニア / React, Next.js, TypeScript
+                    </p>
                   </div>
-                </div>
+                </Link>
               </div>
-              {/* Feedback links */}
-              <div className='flex flex-wrap gap-4 pt-4 border-t border-slate-200 dark:border-slate-700'>
-                <a
-                  href={`https://x.com/search?q=${encodeURIComponent(process.env.SITE_URL + '/blogs/' + blogId)}`}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='text-xs text-slate-500 dark:text-slate-500 hover:text-blue-500 transition-colors'
-                >
-                  Xで議論を見る
-                </a>
+              {/* フィードバック導線。以前は text-slate-400 の極小文字で埋もれていた */}
+              <div className='flex flex-wrap gap-4 pt-4 border-t border-slate-200 dark:border-slate-700 text-sm'>
                 <a
                   href={`https://github.com/j19015/kt-tech.blog/issues/new?title=${encodeURIComponent('[typo] ' + blog.title)}&body=${encodeURIComponent('記事URL: ' + process.env.SITE_URL + '/blogs/' + blogId + '\n\n誤字・修正内容:\n')}`}
                   target='_blank'
                   rel='noopener noreferrer'
-                  className='text-xs text-slate-500 dark:text-slate-500 hover:text-blue-500 transition-colors'
+                  className='inline-flex items-center gap-1.5 text-slate-600 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors'
                 >
-                  誤字を報告する
+                  <Pencil className='w-3.5 h-3.5' aria-hidden='true' />
+                  誤字・間違いを報告する
+                </a>
+                {/* 検索結果ページ（多くの場合0件）ではなく、感想を書ける投稿画面に送る */}
+                <a
+                  href={`https://x.com/intent/tweet?text=${encodeURIComponent(blog.title)}&url=${encodeURIComponent(`${process.env.SITE_URL}/blogs/${blogId}`)}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='inline-flex items-center gap-1.5 text-slate-600 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors'
+                >
+                  <MessageCircle className='w-3.5 h-3.5' aria-hidden='true' />
+                  Xで感想を書く
                 </a>
               </div>
             </div>
@@ -554,6 +589,10 @@ export default async function StaticDetailPage({
           <FloatingTocButton toc={toc} />
           <FloatingShareButton title={blog.title} url={`${process.env.SITE_URL}/blogs/${blog.id}`} />
           </article>
+        </div>
+        {/* 目次は視覚的には右、DOM順では本文のあと */}
+        <div className='lg:col-span-1 lg:order-2 hidden lg:block'>
+          <StickyTableOfContents toc={toc} />
         </div>
       </div>
     </>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,9 +9,7 @@ const notoSansJP = Noto_Sans_JP({
   variable: '--font-noto-sans-jp',
 });
 import { Footer } from '../../src/components/Footer/Footer';
-import { config } from '@fortawesome/fontawesome-svg-core';
 import GoogleAnalytics from '@/components/GoogleAnalytics/GoogleAnalytics';
-import '@fortawesome/fontawesome-svg-core/styles.css';
 import Favicon from './favicon.ico';
 import icon from './icon.png';
 import { Metadata } from 'next';
@@ -21,7 +19,6 @@ import { ScrollToTop } from '@/components/ScrollToTop/ScrollToTop';
 import { WebVitals } from '@/components/WebVitals/WebVitals';
 import { ScrollDepthTracker } from '@/components/Analytics/ScrollDepthTracker';
 import { OutboundLinkTracker } from '@/components/Analytics/OutboundLinkTracker';
-config.autoAddCss = false;
 
 const siteName = 'kt-tech.blog';
 const description = 'フルスタックエンジニアKokiの技術ブログ。React, Next.js, TypeScript, AWSなどの最新技術情報と実践的な開発ノウハウを共有。';

--- a/src/components/TableOfContents/StickyTableOfContents.tsx
+++ b/src/components/TableOfContents/StickyTableOfContents.tsx
@@ -1,7 +1,5 @@
 'use client';
 import { useState, useEffect, useRef } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faListUl } from '@fortawesome/free-solid-svg-icons';
 
 
 interface TocItem {

--- a/src/lib/callout.ts
+++ b/src/lib/callout.ts
@@ -1,0 +1,37 @@
+/**
+ * Notion の callout の色を「意味」に対応づける。
+ *
+ * これまでは `callout-blue_background` のように色名がそのままクラス名になっており、
+ * 見た目由来の名前だったため「あとで情報系calloutの色を変える」ができなかった。
+ * また色と絵文字だけで種別を伝えていたので、色覚特性のあるユーザーには
+ * 何の注意書きなのかが伝わらなかった（WCAG 1.4.1）。
+ */
+export type CalloutKind = 'note' | 'tip' | 'important' | 'warning' | 'caution';
+
+const COLOR_TO_KIND: Record<string, CalloutKind> = {
+  gray: 'note',
+  brown: 'note',
+  default: 'note',
+  green: 'tip',
+  blue: 'important',
+  purple: 'important',
+  yellow: 'warning',
+  orange: 'warning',
+  red: 'caution',
+  pink: 'caution',
+};
+
+/** 種別ごとの既定ラベルとアイコン。書き手が絵文字を指定していればそちらを優先する */
+export const CALLOUT_META: Record<CalloutKind, { label: string; icon: string }> = {
+  note: { label: 'メモ', icon: '📝' },
+  tip: { label: 'Tips', icon: '💡' },
+  important: { label: 'ポイント', icon: '🔖' },
+  warning: { label: '注意', icon: '⚠️' },
+  caution: { label: '重要', icon: '🚨' },
+};
+
+/** Notion の color 値（`blue_background` / `blue` / `default`）から種別を求める */
+export function calloutKindFromColor(color: string): CalloutKind {
+  const base = color.replace(/_background$/, '');
+  return COLOR_TO_KIND[base] ?? 'note';
+}

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -613,148 +613,140 @@
   }
 }
 
-/* Callout / Tips UI */
+/* Callout / Tips UI
+   色ではなく種別（note/tip/important/warning/caution）でスタイルを決める。
+   ラベルを添えることで、色が判別できない環境でも意味が伝わる。 */
 .znc .callout {
+  margin: 1.5rem 0;
+  padding: 0.875rem 1.125rem;
+  border-radius: 8px;
+  border: 1px solid;
+  border-left-width: 4px;
+  /* 本文と同じ文字サイズにする。補足情報が本文より大きいのは不自然だった */
+  font-size: inherit;
+  line-height: 1.85;
+}
+
+.znc .callout__label {
   display: flex;
-  gap: 1rem;
-  padding: 1.25rem 1.5rem;
-  margin: 2rem 0;
-  border-radius: 0.75rem;
-  font-style: normal;
-  line-height: 1.8;
-  border: 1px solid transparent;
-  border-left: 4px solid;
-  font-size: 1.05rem;
-  color: #1e293b;
-}
-.dark .znc .callout {
-  color: #e2e8f0;
+  align-items: center;
+  gap: 0.4em;
+  font-weight: 700;
+  font-size: 0.875em;
+  margin-bottom: 0.4rem;
+  letter-spacing: 0.02em;
 }
 
-.znc .callout-icon {
-  font-size: 1.5rem;
+.znc .callout__icon {
+  /* 絵文字は環境ごとに字形も縦位置も違うので、行の高さに合わせて中央に置く */
+  font-size: 1.05em;
+  line-height: 1;
   flex-shrink: 0;
-  margin-top: 0.15rem;
 }
 
-.znc .callout-content {
-  flex: 1;
-  min-width: 0;
+.znc .callout__body > :first-child {
+  margin-top: 0;
 }
-
-/* 複数段落のcalloutでも段落の区切りが分かるようにする */
-.znc .callout-content p {
-  padding: 0;
-  margin: 0 0 0.75em;
-}
-.znc .callout-content > :last-child {
+.znc .callout__body > :last-child {
   margin-bottom: 0;
 }
-
-.znc .callout-content strong {
-  font-weight: 700;
+.znc .callout__body p {
+  margin: 0 0 0.75em;
+  padding: 0;
 }
-
-.znc .callout-content code {
+.znc .callout__body ul,
+.znc .callout__body ol {
+  margin: 0.5em 0;
+}
+.znc .callout__body code {
   font-size: 0.9em;
 }
 
-/* デフォルト: グレー背景 */
-.znc .callout-default,
-.znc .callout-gray_background {
-  background: #f3f4f6;
-  border-color: #d1d5db;
-  border-left-color: #6b7280;
-}
-.dark .znc .callout-default,
-.dark .znc .callout-gray_background {
-  background: rgba(148, 163, 184, 0.20);
-  border-color: rgba(148, 163, 184, 0.35);
+/* 種別ごとの配色。
+   ダークも半透明ではなく実色で定義する（半透明は下の背景に依存して読みにくくなる）。 */
+.znc .callout--note {
+  background: #f8fafc;
+  border-color: #e2e8f0;
   border-left-color: #94a3b8;
 }
-
-/* 青: 情報・メモ */
-.znc .callout-blue_background {
-  background: #e8f4fd;
-  border-color: #7cb9e8;
-  border-left-color: #2563eb;
+.znc .callout--note .callout__label {
+  color: #475569;
 }
-.dark .znc .callout-blue_background {
-  background: rgba(37, 99, 235, 0.22);
-  border-color: rgba(59, 130, 246, 0.40);
-  border-left-color: #60a5fa;
+.dark .znc .callout--note {
+  background: #1a2436;
+  border-color: #2b3a52;
+  border-left-color: #94a3b8;
+}
+.dark .znc .callout--note .callout__label {
+  color: #cbd5e1;
 }
 
-/* 緑: 成功・Tips */
-.znc .callout-green_background {
-  background: #e6f9ed;
-  border-color: #6ee7a0;
+.znc .callout--tip {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
   border-left-color: #16a34a;
 }
-.dark .znc .callout-green_background {
-  background: rgba(22, 163, 74, 0.22);
-  border-color: rgba(34, 197, 94, 0.40);
+.znc .callout--tip .callout__label {
+  color: #15803d;
+}
+.dark .znc .callout--tip {
+  background: #10291b;
+  border-color: #1a4030;
   border-left-color: #4ade80;
 }
-
-/* 黄色: 注意・警告 */
-.znc .callout-yellow_background {
-  background: #fef9e7;
-  border-color: #f5d44e;
-  border-left-color: #ca8a04;
+.dark .znc .callout--tip .callout__label {
+  color: #86efac;
 }
-.dark .znc .callout-yellow_background {
-  background: rgba(202, 138, 4, 0.22);
-  border-color: rgba(234, 179, 8, 0.40);
+
+.znc .callout--important {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  border-left-color: #2563eb;
+}
+.znc .callout--important .callout__label {
+  color: #1d4ed8;
+}
+.dark .znc .callout--important {
+  background: #16273f;
+  border-color: #1e3a5f;
+  border-left-color: #60a5fa;
+}
+.dark .znc .callout--important .callout__label {
+  color: #93c5fd;
+}
+
+.znc .callout--warning {
+  background: #fffbeb;
+  border-color: #fde68a;
+  border-left-color: #d97706;
+}
+.znc .callout--warning .callout__label {
+  color: #b45309;
+}
+.dark .znc .callout--warning {
+  background: #2e2410;
+  border-color: #4a3a15;
   border-left-color: #facc15;
 }
+.dark .znc .callout--warning .callout__label {
+  color: #fcd34d;
+}
 
-/* 赤: 危険・重要 */
-.znc .callout-red_background {
-  background: #fde8e8;
-  border-color: #f87171;
+.znc .callout--caution {
+  background: #fef2f2;
+  border-color: #fecaca;
   border-left-color: #dc2626;
 }
-.dark .znc .callout-red_background {
-  background: rgba(220, 38, 38, 0.22);
-  border-color: rgba(239, 68, 68, 0.40);
+.znc .callout--caution .callout__label {
+  color: #b91c1c;
+}
+.dark .znc .callout--caution {
+  background: #2e1618;
+  border-color: #4a2226;
   border-left-color: #f87171;
 }
-
-/* 紫 */
-.znc .callout-purple_background {
-  background: #f3e8ff;
-  border-color: #c084fc;
-  border-left-color: #7c3aed;
-}
-.dark .znc .callout-purple_background {
-  background: rgba(124, 58, 237, 0.22);
-  border-color: rgba(168, 85, 247, 0.40);
-  border-left-color: #a78bfa;
-}
-
-/* ピンク */
-.znc .callout-pink_background {
-  background: #fce7f3;
-  border-color: #f472b6;
-  border-left-color: #db2777;
-}
-.dark .znc .callout-pink_background {
-  background: rgba(219, 39, 119, 0.22);
-  border-color: rgba(236, 72, 153, 0.40);
-  border-left-color: #f472b6;
-}
-
-/* オレンジ */
-.znc .callout-orange_background {
-  background: #fff3e0;
-  border-color: #fb923c;
-  border-left-color: #ea580c;
-}
-.dark .znc .callout-orange_background {
-  background: rgba(234, 88, 12, 0.22);
-  border-color: rgba(249, 115, 22, 0.40);
-  border-left-color: #fb923c;
+.dark .znc .callout--caution .callout__label {
+  color: #fca5a5;
 }
 
 /* ブログの目次のCSS - グローバル変数を上書きしない */


### PR DESCRIPTION
## What

Callout/Tips のデザインを「色」から「意味」ベースに作り直し、記事詳細の順序を **タイトル → メタ → 本文** に変えました。

Closes #350
Closes #351
Closes #352
Closes #395
Closes #413
Closes #421
Closes #422
Closes #424
Closes #425
Closes #453
Closes #454
Closes #461
Closes #462
Closes #486

## Why

### Callout が「色と絵文字」でしか意味を伝えていなかった

Notion の色がそのままクラス名（`callout-blue_background`）になっており、**見た目由来の名前**でした。読者側も色と絵文字だけが手がかりで、色を判別できない環境では何の注意書きなのか分かりません（WCAG 1.4.1）。

色 → 種別（note / tip / important / warning / caution）にマッピングし、**ラベルを添える**形にしました。

| Notionの色 | 種別 | ラベル |
|---|---|---|
| gray / brown / default | note | 📝 メモ |
| green | tip | 💡 Tips |
| blue / purple | important | 🔖 ポイント |
| yellow / orange | warning | ⚠️ 注意 |
| red / pink | caution | 🚨 重要 |

書き手が Notion で選んだ絵文字はそのまま活きます（未指定なら種別の既定アイコン）。

あわせて:
- **文字サイズを本文と同じに**（補足情報が本文より大きいのは不自然でした）
- **マージンを 2rem → 1.5rem**（h2 の余白に迫る大きさで、前後の文章を分断していた）
- **ダークの背景を実色に**。以前は `rgba(色, 0.22)` の半透明で、下地に依存して読みにくくなるうえ、ライトだけ不透明・ダークだけ半透明という非対称な作りでした

### 記事を開いても何の記事か分からなかった

以前の順序: **アイキャッチ → カテゴリ/日付/読了時間 → タグ → タイトル**

検索から来た読者が「求めていた記事か」を判断するまでにスクロールが必要でした。**タイトル → コンパクトなメタ1行 → アイキャッチ（21:9）→ 本文** に変更。アイキャッチは Gemini 生成の抽象画像で内容を説明しないため、ファーストビューを占有しないようにしています。

### 目次が左で、本文の開始位置が右にずれていた

主コンテンツである本文が画面の右2/3に押しやられ、視線の起点（左上）に来るのが補助情報でした。**目次を右**に移し、`order` を使って **DOM順は本文が先**のままにしています（スクリーンリーダーと検索エンジンにも本文が先に届く）。

### 記事末尾が5ブロック積み上がっていた

シェア（2回目）→ 著者カード（リンク先なし）→ フィードバック（12px の slate-400）→ 前後記事 → 関連記事。

- シェアは**末尾の1箇所のみ**に
- **著者カードを /about にリンク**（行き止まりだった）
- **記事のタグを末尾にも配置**。以前は冒頭にしかなく、読み終えた時点では数千px上でした
- 「Xで議論を見る」は**ほとんどの記事で0件の検索結果**に飛んでいたので、感想を書ける投稿画面に変更

## How

- `src/lib/callout.ts` に色→種別のマッピングを切り出し
- FontAwesome を lucide に統一。**`@fortawesome/*` 4パッケージと グローバルCSSの参照を完全に除去**しました（`StickyTableOfContents` は `faListUl` を import だけして使っていませんでした）
- 読了時間の計算が `stripHtml(processedHtml)` で3箇所に散っていたので1箇所に

## Testing

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx next build` — Compiled successfully
- [x] `npm run lint` — 新規warningなし
- [x] **5種類のcallout・引用・見出しをローカルレンダリングしてライト/ダーク両方を目視確認**

見出し（下ボーダー）/ 引用（左バー+薄い背景）/ callout（角丸ボックス+ラベル）の3つが、それぞれ別物として読めることを確認しています。

## Screenshots

ライト・ダークともに、種別ごとの配色とラベルで意味が伝わる状態です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_