### PR TITLE
feat: 連載（シリーズ）機能を追加する

### DIFF
--- a/libs/notion.ts
+++ b/libs/notion.ts
@@ -20,6 +20,13 @@ async function notionFetch(path: string, options: { method?: string; body?: any;
 }
 
 // 既存のmicrocms.tsと同じ型インターフェースを維持
+/** 連載。Notion の `Series`（Select）と `SeriesOrder`（Number）から作る */
+export type Series = {
+  name: string;
+  /** 連載内の順序。未設定なら 0（公開日順にフォールバックする） */
+  order: number;
+};
+
 export type Blog = {
   id: string; // Slug (microCMS IDまたはNotion page ID)
   title: string;
@@ -28,6 +35,7 @@ export type Blog = {
   eyecatch?: { url: string; height?: number; width?: number };
   category?: Category;
   tags?: Tag[];
+  series?: Series;
   createdAt: string;
   updatedAt: string;
   publishedAt: string;
@@ -311,6 +319,10 @@ async function pageToBlog(page: any, fetchBody: boolean = false): Promise<Blog> 
   const createdDate = props.Created?.date?.start || page.created_time;
   const id = slug || page.id.replace(/-/g, '');
 
+  // 連載。プロパティが未作成のデータベースでも落ちないよう、全て省略可能に扱う。
+  const seriesName = (props.Series?.select?.name || '').trim();
+  const seriesOrder = typeof props.SeriesOrder?.number === 'number' ? props.SeriesOrder.number : 0;
+
   let body = '';
   if (fetchBody) {
     body = await blocksToMarkdown(page.id);
@@ -326,6 +338,7 @@ async function pageToBlog(page: any, fetchBody: boolean = false): Promise<Blog> 
     eyecatch: eyecatchUrl ? { url: eyecatchUrl, width: 1200, height: 630 } : undefined,
     category: categoryName ? pageToCategory(categoryName) : undefined,
     tags,
+    series: seriesName ? { name: seriesName, order: seriesOrder } : undefined,
     createdAt,
     updatedAt: page.last_edited_time,
     publishedAt: createdAt,

--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -49,6 +49,8 @@ import { ImageLightbox } from '@/components/ImageLightbox/ImageLightbox';
 import { KeyboardNav } from '@/components/KeyboardNav/KeyboardNav';
 import { FloatingTocButton } from '@/components/TableOfContents/FloatingTocButton';
 import { BookmarkButton } from '@/components/Bookmark/BookmarkButton';
+import { SeriesNav } from '@/components/Series/SeriesNav';
+import { findSeriesOf } from '@/lib/series';
 import { isPublic } from '@/lib/blog';
 import { calloutKindFromColor, CALLOUT_META } from '@/lib/callout';
 // カレンダー・フォルダの3アイコンのために FontAwesome 一式を読み込んでいたので lucide に統一
@@ -155,6 +157,12 @@ export default async function StaticDetailPage({
   // 前後記事・関連記事はPF記事を除いた一覧から選ぶ。
   // 一覧に出ていない記事へ飛ばされると導線が破綻するため。
   const navPosts = contents.filter(isPublic);
+
+  // 連載。連載名と順序は Notion のプロパティで持つので、新しい保存先は増やしていない。
+  const seriesContext = findSeriesOf(navPosts, blog);
+  const nextInSeries = seriesContext
+    ? seriesContext.series.posts[seriesContext.index + 1] ?? null
+    : null;
 
   // 関連記事をスコアリングで取得（タグ重複数 + カテゴリ一致で重み付け）
   const blogTagIds = blog.tags?.map(t => t.id) || [];
@@ -410,6 +418,18 @@ export default async function StaticDetailPage({
                 priority
               />
             </header>
+            {/* 連載の目次は本文より前。途中から流入した読者に、
+                これが何回目でどこから読むべきかを最初に伝えるため。 */}
+            {seriesContext && (
+              <div className='mx-4'>
+                <SeriesNav
+                  seriesName={seriesContext.series.name}
+                  seriesHref={`/series/${encodeURIComponent(seriesContext.series.slug)}`}
+                  posts={seriesContext.series.posts.map((p) => ({ id: p.id, title: p.title }))}
+                  currentIndex={seriesContext.index}
+                />
+              </div>
+            )}
             <TableOfContents toc={toc} />
             <div className='p-4 znc markdown text-foreground'>
               <div dangerouslySetInnerHTML={{ __html: processedHtml }}></div>
@@ -487,6 +507,26 @@ export default async function StaticDetailPage({
                 </a>
               </div>
             </div>
+            {/* 連載の続きは公開日順の前後記事より優先して出す。
+                PostNavigation は公開日順なので、連載の間に別記事を挟むと順序が崩れる。 */}
+            {nextInSeries && seriesContext && (
+              <div className='mt-10 mx-4'>
+                <Link
+                  href={`/blogs/${nextInSeries.id}`}
+                  className='flex items-center gap-3 rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-blue-400 hover:bg-blue-50/50 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-blue-500 dark:hover:bg-slate-700/50'
+                >
+                  <span className='min-w-0 flex-1'>
+                    <span className='block text-xs text-slate-500 dark:text-slate-400'>
+                      連載の次の記事（{seriesContext.index + 2} / {seriesContext.series.posts.length}）
+                    </span>
+                    <span className='mt-0.5 block font-semibold text-slate-900 dark:text-slate-100'>
+                      {nextInSeries.title}
+                    </span>
+                  </span>
+                  <span aria-hidden='true' className='shrink-0 text-slate-400'>→</span>
+                </Link>
+              </div>
+            )}
             <PostNavigation currentId={blogId} allPosts={navPosts} />
             {(() => {
               const idx = navPosts.findIndex(p => p.id === blogId);

--- a/src/app/series/[seriesSlug]/page.tsx
+++ b/src/app/series/[seriesSlug]/page.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
+import { Library, BookOpen } from 'lucide-react';
+import { getList } from '../../../../libs/notion';
+import { BreadcrumbNav } from '@/components/Breadcrumb/BreadcrumbNav';
+import { groupBySeries } from '@/lib/series';
+import { SeriesPostList } from '@/components/Series/SeriesPostList';
+
+const siteUrl = process.env.SITE_URL || 'https://kt-tech.blog';
+
+export const runtime = 'edge';
+
+type Props = { params: Promise<{ seriesSlug: string }> };
+
+/**
+ * slug から連載を引く。
+ *
+ * slug → 連載名の対応表は持たず、毎回全記事から作り直している。
+ * 連載の数はたかが知れているし、対応表を別に保存すると
+ * Notion 側で連載名を変えたときに二重管理になるため。
+ */
+async function findSeries(slugParam: string) {
+  const slug = decodeURIComponent(slugParam);
+  const { contents } = await getList().catch(() => ({ contents: [], totalCount: 0, offset: 0, limit: 0 }));
+  return groupBySeries(contents).find((s) => s.slug === slug) ?? null;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { seriesSlug } = await params;
+  const series = await findSeries(seriesSlug);
+  if (!series) {
+    return { title: '連載が見つかりません', robots: { index: false, follow: false } };
+  }
+
+  const title = `${series.name}（全${series.posts.length}回）`;
+  const description = `連載「${series.name}」の記事一覧です。第1回から順に読めます。`;
+  const url = `${siteUrl}/series/${seriesSlug}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: { title, description, url, type: 'website' },
+    twitter: { card: 'summary', title, description },
+  };
+}
+
+export default async function SeriesDetailPage({ params }: Props) {
+  const { seriesSlug } = await params;
+  const series = await findSeries(seriesSlug);
+  if (!series) notFound();
+
+  return (
+    <div className='max-w-4xl mx-auto px-4 pb-16'>
+      <BreadcrumbNav
+        items={[
+          { label: 'Series', href: '/series' },
+          { label: series.name, current: true },
+        ]}
+      />
+
+      <div className='flex items-center gap-2 px-2'>
+        <Library className='h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400' aria-hidden='true' />
+        <h1 className='text-2xl md:text-3xl font-bold text-slate-900 dark:text-slate-100'>{series.name}</h1>
+      </div>
+      <p className='mt-2 px-2 text-sm text-slate-500 dark:text-slate-400'>全{series.posts.length}回</p>
+
+      <Link
+        href={`/blogs/${series.posts[0].id}`}
+        className='mt-4 mb-8 mx-2 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700'
+      >
+        <BookOpen className='h-4 w-4' aria-hidden='true' />
+        第1回から読む
+      </Link>
+
+      {/* 検索エンジンに「順序のある記事の集まり」だと伝える */}
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'ItemList',
+            name: series.name,
+            numberOfItems: series.posts.length,
+            itemListOrder: 'https://schema.org/ItemListOrderAscending',
+            itemListElement: series.posts.map((post, i) => ({
+              '@type': 'ListItem',
+              position: i + 1,
+              url: `${siteUrl}/blogs/${post.id}`,
+              name: post.title,
+            })),
+          }),
+        }}
+      />
+
+      <SeriesPostList
+        posts={series.posts.map((p) => ({ id: p.id, title: p.title, publishedAt: p.publishedAt }))}
+      />
+    </div>
+  );
+}

--- a/src/app/series/page.tsx
+++ b/src/app/series/page.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { Metadata } from 'next';
+import { Library } from 'lucide-react';
+import { getList } from '../../../libs/notion';
+import { BreadcrumbNav } from '@/components/Breadcrumb/BreadcrumbNav';
+import { groupBySeries } from '@/lib/series';
+import { formatArchive } from '@/lib/blog';
+
+const siteUrl = process.env.SITE_URL || 'https://kt-tech.blog';
+
+export const metadata: Metadata = {
+  title: '連載一覧',
+  description: '複数回に分けて書いた連載記事の一覧です。第1回から順に読めます。',
+  alternates: { canonical: `${siteUrl}/series` },
+};
+
+export const runtime = 'edge';
+
+export default async function SeriesIndexPage() {
+  const { contents } = await getList().catch(() => ({ contents: [], totalCount: 0, offset: 0, limit: 0 }));
+  const seriesList = groupBySeries(contents);
+
+  return (
+    <div className='max-w-4xl mx-auto px-4 pb-16'>
+      <BreadcrumbNav items={[{ label: 'Series', current: true }]} />
+
+      <h1 className='text-2xl md:text-3xl font-bold text-slate-900 dark:text-slate-100 px-2'>連載</h1>
+      <p className='mt-2 mb-8 px-2 text-sm text-slate-500 dark:text-slate-400'>
+        {seriesList.length}件の連載・全{seriesList.reduce((n, s) => n + s.posts.length, 0)}記事
+      </p>
+
+      {seriesList.length === 0 ? (
+        <p className='px-2 text-slate-500 dark:text-slate-400'>連載記事はまだありません。</p>
+      ) : (
+        <ul className='space-y-4 px-2'>
+          {seriesList.map((series) => (
+            <li key={series.slug}>
+              <Link
+                href={`/series/${encodeURIComponent(series.slug)}`}
+                className='block rounded-xl border border-slate-200 bg-white p-5 transition-colors hover:border-blue-400 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-blue-500'
+              >
+                <div className='flex items-center gap-2'>
+                  <Library className='h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400' aria-hidden='true' />
+                  <h2 className='min-w-0 flex-1 font-bold text-slate-900 dark:text-slate-100'>{series.name}</h2>
+                  <span className='shrink-0 text-xs text-slate-500 dark:text-slate-400'>全{series.posts.length}回</span>
+                </div>
+                {/* 第1回のタイトルまで見せると、何の話の連載かが一覧で分かる */}
+                <p className='mt-2 truncate text-sm text-slate-600 dark:text-slate-300'>
+                  1. {series.posts[0].title}
+                </p>
+                <p className='mt-1 text-xs text-slate-400 dark:text-slate-500'>
+                  最終更新 {formatArchive(series.updatedAt.slice(0, 7))}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next';
 import { getList, getCategoryList, getTagList } from '../../libs/notion';
 import { ITEMS_PER_PAGE, isPublic } from '@/lib/blog';
+import { groupBySeries } from '@/lib/series';
 
 export const runtime = 'edge';
 
@@ -51,6 +52,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.5,
   }));
 
+  // Series pages
+  const seriesList = groupBySeries(contents);
+  const seriesEntries: MetadataRoute.Sitemap = seriesList.map((series) => ({
+    url: `${siteUrl}/series/${encodeURIComponent(series.slug)}`,
+    lastModified: new Date(series.updatedAt),
+    changeFrequency: 'weekly' as const,
+    priority: 0.6,
+  }));
+
   // Archive pages (unique year-month from articles)
   const archiveMonths = new Set(
     allBlogs.map((b) => {
@@ -90,6 +100,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'weekly',
       priority: 0.6,
     },
+    ...(seriesList.length > 0
+      ? [
+          {
+            url: `${siteUrl}/series`,
+            lastModified: latestUpdated,
+            changeFrequency: 'weekly' as const,
+            priority: 0.6,
+          },
+        ]
+      : []),
   ];
 
   return [
@@ -97,6 +117,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...paginationEntries,
     ...categoryEntries,
     ...tagEntries,
+    ...seriesEntries,
     ...archiveEntries,
     ...blogEntries,
   ];

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -75,6 +75,11 @@ export const Footer = () => {
                 </Link>
               </li>
               <li>
+                <Link href='/series' className='text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 transition-colors'>
+                  Series
+                </Link>
+              </li>
+              <li>
                 <Link href='/categories' className='text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 transition-colors'>
                   Categories
                 </Link>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,13 +4,14 @@ import Image from 'next/image';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
 import { ModeToggle } from '../ModeToggle/modeToggle';
-import { Menu, X, Home, BookOpen, User, Search, Github } from 'lucide-react';
+import { Menu, X, Home, BookOpen, User, Search, Github, Library } from 'lucide-react';
 import { SearchModal } from '../SearchModal/SearchModal';
 import { useDialog } from '@/lib/useDialog';
 
 const MENU_ITEMS = [
   { name: 'Home', href: '/', icon: Home },
   { name: 'Blog', href: '/blogs/page/1', icon: BookOpen },
+  { name: 'Series', href: '/series', icon: Library },
   { name: 'About', href: '/about', icon: User },
 ];
 

--- a/src/components/Index/Index.tsx
+++ b/src/components/Index/Index.tsx
@@ -3,6 +3,7 @@ import { BlogProps } from '../../../libs/notion';
 import Link from 'next/link';
 import Image from 'next/image';
 import { FadeIn } from '../FadeIn/FadeIn';
+import { Library } from 'lucide-react';
 
 const timeAgo = (date: string) => {
   const diff = Date.now() - new Date(date).getTime();
@@ -47,9 +48,24 @@ export const Index = ({ contents }: BlogProps) => {
 
                 {/* コンテンツ */}
                 <div className='flex-1 min-w-0 flex flex-col justify-between py-0.5'>
-                  <h2 className='text-sm sm:text-base font-semibold text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2 leading-snug'>
-                    {blog.title}
-                  </h2>
+                  <div className='min-w-0'>
+                    {/* 連載バッジ。一覧の時点で「これは連載の一部」と分かると、
+                        途中の回を単発記事だと思って読み始めるのを防げる */}
+                    {blog.series && (
+                      <span className='mb-1 flex items-center gap-1 text-[10px] font-semibold text-blue-600 dark:text-blue-400'>
+                        <Library className='h-3 w-3 shrink-0' aria-hidden='true' />
+                        <span className='truncate'>{blog.series.name}</span>
+                        {blog.series.order > 0 && (
+                          <span className='shrink-0 tabular-nums text-slate-400 dark:text-slate-500'>
+                            #{blog.series.order}
+                          </span>
+                        )}
+                      </span>
+                    )}
+                    <h2 className='text-sm sm:text-base font-semibold text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2 leading-snug'>
+                      {blog.title}
+                    </h2>
+                  </div>
 
                   <div className='space-y-1.5'>
                     <div className='flex items-center gap-1.5 text-[11px] text-slate-500 dark:text-slate-400'>

--- a/src/components/ReadingStats/ReadingStats.tsx
+++ b/src/components/ReadingStats/ReadingStats.tsx
@@ -1,17 +1,15 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { BookOpen } from 'lucide-react';
-
-const STORAGE_KEY = 'kt-tech-read-articles';
+import { READ_ARTICLES_KEY, getReadArticles } from '@/lib/readArticles';
 
 export const useReadingTracker = (articleId?: string) => {
   useEffect(() => {
     if (!articleId || typeof window === 'undefined') return;
     try {
-      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as string[];
+      const stored = getReadArticles();
       if (!stored.includes(articleId)) {
-        stored.push(articleId);
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+        localStorage.setItem(READ_ARTICLES_KEY, JSON.stringify([...stored, articleId]));
       }
     } catch {}
   }, [articleId]);
@@ -22,8 +20,7 @@ export const ReadingStats = () => {
 
   useEffect(() => {
     try {
-      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as string[];
-      setCount(stored.length);
+      setCount(getReadArticles().length);
     } catch {}
   }, []);
 

--- a/src/components/ReadingStats/ReadingTracker.tsx
+++ b/src/components/ReadingStats/ReadingTracker.tsx
@@ -1,16 +1,14 @@
 'use client';
 import { useEffect } from 'react';
-
-const STORAGE_KEY = 'kt-tech-read-articles';
+import { READ_ARTICLES_KEY, getReadArticles } from '@/lib/readArticles';
 
 export const ReadingTracker = ({ articleId }: { articleId: string }) => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     try {
-      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as string[];
+      const stored = getReadArticles();
       if (!stored.includes(articleId)) {
-        stored.push(articleId);
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+        localStorage.setItem(READ_ARTICLES_KEY, JSON.stringify([...stored, articleId]));
       }
     } catch {}
   }, [articleId]);

--- a/src/components/Series/SeriesNav.tsx
+++ b/src/components/Series/SeriesNav.tsx
@@ -1,0 +1,85 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Library, Check } from 'lucide-react';
+import { getReadArticles } from '@/lib/readArticles';
+
+export type SeriesNavItem = { id: string; title: string };
+
+type Props = {
+  seriesName: string;
+  seriesHref: string;
+  posts: SeriesNavItem[];
+  /** 現在表示中の記事の位置（0始まり） */
+  currentIndex: number;
+};
+
+/**
+ * 記事本文の前に置く連載の目次。
+ *
+ * 連載の途中から流入した読者に「これは何回目で、前に何があるのか」を
+ * 最初に伝えるのが目的なので、本文より前に置いている。
+ * 既読の印だけはクライアントでしか分からないため Client Component。
+ */
+export const SeriesNav = ({ seriesName, seriesHref, posts, currentIndex }: Props) => {
+  const [read, setRead] = useState<string[]>([]);
+
+  useEffect(() => {
+    setRead(getReadArticles());
+  }, []);
+
+  return (
+    <nav
+      aria-label={`連載「${seriesName}」の記事一覧`}
+      className='my-6 rounded-xl border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800/50'
+    >
+      <div className='flex items-center gap-2 border-b border-slate-200 px-4 py-2.5 dark:border-slate-700'>
+        <Library className='h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400' aria-hidden='true' />
+        <Link
+          href={seriesHref}
+          className='min-w-0 flex-1 truncate text-sm font-semibold text-slate-800 hover:underline dark:text-slate-100'
+        >
+          {seriesName}
+        </Link>
+        <span className='shrink-0 text-xs text-slate-500 dark:text-slate-400'>
+          {currentIndex + 1} / {posts.length}
+        </span>
+      </div>
+
+      <ol className='py-1'>
+        {posts.map((post, i) => {
+          const isCurrent = i === currentIndex;
+          // 現在地は既読の印を出さない。今読んでいる記事にチェックが付くのは紛らわしい
+          const isRead = !isCurrent && read.includes(post.id);
+          return (
+            <li key={post.id}>
+              {isCurrent ? (
+                <span
+                  aria-current='page'
+                  className='flex items-baseline gap-2 border-l-2 border-blue-500 bg-blue-50 px-4 py-1.5 text-sm font-semibold text-slate-900 dark:bg-blue-950/40 dark:text-slate-100'
+                >
+                  <span className='shrink-0 tabular-nums text-slate-500 dark:text-slate-400'>{i + 1}.</span>
+                  <span className='min-w-0'>{post.title}</span>
+                </span>
+              ) : (
+                <Link
+                  href={`/blogs/${post.id}`}
+                  className='flex items-baseline gap-2 border-l-2 border-transparent px-4 py-1.5 text-sm text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-700/50 dark:hover:text-slate-100'
+                >
+                  <span className='shrink-0 tabular-nums text-slate-400 dark:text-slate-500'>{i + 1}.</span>
+                  <span className='min-w-0'>{post.title}</span>
+                  {isRead && (
+                    <Check
+                      className='ml-auto h-3.5 w-3.5 shrink-0 self-center text-green-600 dark:text-green-500'
+                      aria-label='読了済み'
+                    />
+                  )}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+};

--- a/src/components/Series/SeriesPostList.tsx
+++ b/src/components/Series/SeriesPostList.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Check } from 'lucide-react';
+import { getReadArticles } from '@/lib/readArticles';
+
+export type SeriesPost = { id: string; title: string; publishedAt: string };
+
+/**
+ * 連載詳細ページの記事リスト。
+ *
+ * 既読の印は localStorage にしかないので Client Component にしている。
+ * リンクとタイトルはサーバー側から props で受け取るため、
+ * JS が動かなくても一覧としては成立する。
+ */
+export const SeriesPostList = ({ posts }: { posts: SeriesPost[] }) => {
+  const [read, setRead] = useState<string[]>([]);
+
+  useEffect(() => {
+    setRead(getReadArticles());
+  }, []);
+
+  return (
+    <ol className='space-y-3 px-2'>
+      {posts.map((post, i) => {
+        const isRead = read.includes(post.id);
+        return (
+          <li key={post.id}>
+            <Link
+              href={`/blogs/${post.id}`}
+              className='flex items-baseline gap-3 rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-blue-400 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-blue-500'
+            >
+              <span className='shrink-0 tabular-nums text-sm font-bold text-slate-400 dark:text-slate-500'>
+                {i + 1}
+              </span>
+              <span className='min-w-0 flex-1'>
+                <span className='block font-semibold text-slate-900 dark:text-slate-100'>{post.title}</span>
+                <time
+                  dateTime={post.publishedAt}
+                  className='mt-1 block text-xs text-slate-400 dark:text-slate-500'
+                >
+                  {post.publishedAt.slice(0, 10).replace(/-/g, '/')}
+                </time>
+              </span>
+              {isRead && (
+                <span className='flex shrink-0 items-center gap-1 self-center text-xs text-green-600 dark:text-green-500'>
+                  <Check className='h-3.5 w-3.5' aria-hidden='true' />
+                  読了
+                </span>
+              )}
+            </Link>
+          </li>
+        );
+      })}
+    </ol>
+  );
+};

--- a/src/lib/readArticles.ts
+++ b/src/lib/readArticles.ts
@@ -1,0 +1,18 @@
+/**
+ * 既読記事の localStorage キー。
+ *
+ * ReadingTracker / ReadingStats / SeriesNav の3箇所で同じキーを
+ * 別々に書いていたので、片方だけ直すと静かにずれる状態だった。
+ */
+export const READ_ARTICLES_KEY = 'kt-tech-read-articles';
+
+/** 既読記事のIDを読む。壊れた値が入っていても落とさない */
+export function getReadArticles(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = JSON.parse(localStorage.getItem(READ_ARTICLES_KEY) || '[]');
+    return Array.isArray(stored) ? stored.filter((v): v is string => typeof v === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/series.ts
+++ b/src/lib/series.ts
@@ -1,0 +1,70 @@
+import type { Blog } from '../../libs/notion';
+import { isPublic } from './blog';
+
+export type SeriesSummary = {
+  name: string;
+  /** 連載名から作った URL 用の識別子 */
+  slug: string;
+  /** 第1回から順に並んだ記事 */
+  posts: Blog[];
+  /** 連載の最終更新日（＝一番新しい記事の公開日） */
+  updatedAt: string;
+};
+
+/**
+ * 連載名を URL に載せる識別子に変換する。
+ *
+ * 日本語の連載名を想定しているのでローマ字化はせず、
+ * URL で扱いに困る記号だけを落とす。`/series/[seriesSlug]` 側では
+ * 逆引きせず、全連載を舐めて slug 一致で探す
+ * （連載の数はたかが知れているし、別テーブルを持たずに済む）。
+ */
+export function seriesSlug(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/["'<>`#%\\/?&=+]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+/**
+ * 記事一覧を連載ごとにまとめる。
+ *
+ * 並び順は `SeriesOrder` の昇順。未設定（0）の記事が混ざっても
+ * 破綻しないよう、同値のときは公開日の古い順で決める。
+ */
+export function groupBySeries(blogs: Blog[]): SeriesSummary[] {
+  const byName = new Map<string, Blog[]>();
+  for (const blog of blogs) {
+    if (!isPublic(blog) || !blog.series) continue;
+    const list = byName.get(blog.series.name);
+    if (list) list.push(blog);
+    else byName.set(blog.series.name, [blog]);
+  }
+
+  return Array.from(byName.entries())
+    .map(([name, posts]) => {
+      const sorted = [...posts].sort(
+        (a, b) =>
+          (a.series?.order ?? 0) - (b.series?.order ?? 0) ||
+          new Date(a.publishedAt).getTime() - new Date(b.publishedAt).getTime()
+      );
+      const updatedAt = sorted.reduce(
+        (latest, p) => (new Date(p.publishedAt) > new Date(latest) ? p.publishedAt : latest),
+        sorted[0].publishedAt
+      );
+      return { name, slug: seriesSlug(name), posts: sorted, updatedAt };
+    })
+    // 更新の新しい連載を先に見せる
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+}
+
+/** 指定記事が属する連載と、その中での位置を返す */
+export function findSeriesOf(blogs: Blog[], blog: Blog): { series: SeriesSummary; index: number } | null {
+  if (!blog.series) return null;
+  const series = groupBySeries(blogs).find((s) => s.name === blog.series!.name);
+  if (!series) return null;
+  const index = series.posts.findIndex((p) => p.id === blog.id);
+  if (index < 0) return null;
+  return { series, index };
+}


### PR DESCRIPTION
順序のある記事群を「連載」として扱えるようにしました。第3回にたどり着いた読者が第1回の存在に気づけず、続きへの導線もない状態を解消するのが目的です。

## データの持ち方

Notion のプロパティ2つだけで表現します。**新しいデータストアは追加していません**。

| プロパティ | 型 | 用途 |
| --- | --- | --- |
| `Series` | Select | 連載名 |
| `SeriesOrder` | Number | 連載内の順序 |

どちらも省略可能として扱うので、プロパティを作る前のデータベースでもそのまま動きます。`SeriesOrder` が未設定（0）でも公開日順にフォールバックするため、順序を付け忘れた連載で並びが破綻することもありません。

`getList()` の結果をグルーピングしているだけなので、API 呼び出しは増えていません。

## 記事詳細（#435）

- **本文の前**に連載の目次。途中から流入した読者に「これが何回目で、前に何があるのか」を最初に伝えたいので、本文より前に置きました。現在地をハイライトし、既読の記事にはチェックを付けます。
- 記事末尾に「連載の次の記事」。`PostNavigation` は公開日順なので、連載の間に別記事を挟むと順序が崩れます。連載の続きはそれとは別に、前後記事より前に出しています。
- 一覧カードに連載バッジ。途中の回を単発記事だと思って読み始めるのを防げます。

## `/series` と `/series/[seriesSlug]`（#436）

- `/series`: 連載名・回数・第1回のタイトル・最終更新
- `/series/[seriesSlug]`: `SeriesOrder` 順の全記事、読了マーク、「第1回から読む」、`ItemList` の構造化データ
- ヘッダー / フッター / sitemap に導線を追加

slug → 連載名の対応表は持たず、毎回全記事から作り直しています。連載の数はたかが知れていますし、対応表を別に保存すると Notion 側で連載名を変えたときに二重管理になるためです。

## ついでに直したところ

既読判定の localStorage アクセスが `ReadingTracker` / `ReadingStats` / 新規コンポーネントの3箇所に分かれ、キー文字列がそれぞれ直書きされていたので `src/lib/readArticles.ts` に集約しました。

## やらなかったこと

#436 にある「総読了時間の目安」は入れていません。`getList()` は本文を取得しない（`pageToBlog(page, false)`）ので、記事数ぶんの追加 API 呼び出しなしには読了時間を計算できないためです。同じ理由で `Index` の「N分で読める」も一覧ページでは表示されていない状態になっています（本 PR とは別の既存の問題なので、別 Issue として扱うのが適切だと思います）。

「完結済み / 連載中」のステータスも見送りました。判定基準を最終更新からの経過で決めると、単に間が空いただけの連載が「完結」と表示されてしまうためです。必要なら `SeriesStatus` プロパティを足すのが確実です。

## 確認したこと

- `tsc --noEmit` / `next lint` クリーン、`next build` は「✓ Compiled successfully」（`/searches` の prerender 失敗はサンドボックスから Notion API に出られないためで、変更とは無関係）
- `groupBySeries` / `findSeriesOf` をデータを与えて実行し、以下を確認:
  - PF カテゴリの記事が連載から除外されること
  - `SeriesOrder` 順に並ぶこと
  - `SeriesOrder` 未設定のときに公開日の古い順へフォールバックすること
  - 連載一覧が最終更新の新しい順に並ぶこと
  - 最終回で「次の記事」が `null` になること
- Chromium で `SeriesNav` をライト/ダーク両方でレンダリングし、現在地のハイライトと既読チェックの表示を確認

Closes #435
Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_