### PR TITLE
fix: 検索を実際に使えるものにする

### DIFF
--- a/src/app/api/search-index/route.ts
+++ b/src/app/api/search-index/route.ts
@@ -1,0 +1,38 @@
+import { getList } from '../../../../libs/notion';
+import { isPublic } from '@/lib/blog';
+
+export const runtime = 'edge';
+
+/**
+ * 検索モーダルの候補表示に使う軽量インデックス。
+ *
+ * 本文は含めない。`getList()` はそもそも本文を取得しないし、
+ * 全記事の本文を返せば数百KBになってモーダルを開くたびに転送することになる。
+ * タイトル・タグ・カテゴリだけなら記事が増えても数十KBに収まる。
+ *
+ * 新しいデータの置き場は作っていない。既に持っているものを返すだけ。
+ */
+export async function GET() {
+  try {
+    const { contents } = await getList();
+    const index = contents.filter(isPublic).map((blog) => ({
+      id: blog.id,
+      title: blog.title,
+      description: blog.ogpDescription ?? '',
+      tags: blog.tags?.map((t) => t.name) ?? [],
+      category: blog.category?.name ?? '',
+      series: blog.series?.name ?? '',
+    }));
+
+    return Response.json(index, {
+      headers: {
+        // 記事の追加が数分遅れて見えるのは許容できる。
+        // モーダルを開くたびに Notion API を叩くほうが問題。
+        'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600',
+      },
+    });
+  } catch {
+    // 候補が出ないだけで検索自体は /searches で完結するので、空配列を返して黙って諦める
+    return Response.json([], { status: 200, headers: { 'Cache-Control': 'no-store' } });
+  }
+}

--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next';
+import { BookmarkList } from '@/components/Bookmark/BookmarkList';
+import { BreadcrumbNav } from '@/components/Breadcrumb/BreadcrumbNav';
+
+export const metadata: Metadata = {
+  title: 'あとで読む',
+  description: '「あとで読む」で保存した記事の一覧です。',
+  // 保存内容は端末ごとに違うので、検索エンジンに拾わせても意味がない
+  robots: { index: false, follow: false },
+};
+
+export default function BookmarksPage() {
+  return (
+    <div className='max-w-3xl mx-auto px-4 pb-16'>
+      <BreadcrumbNav items={[{ label: 'Bookmarks', current: true }]} />
+      <h1 className='text-2xl md:text-3xl font-bold text-slate-900 dark:text-slate-100 px-2'>あとで読む</h1>
+      <p className='mt-2 mb-8 px-2 text-sm text-slate-500 dark:text-slate-400'>
+        この端末のブラウザに保存されています。他の端末とは共有されません。
+      </p>
+      <BookmarkList />
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -106,7 +106,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       '@type': 'SearchAction',
       target: {
         '@type': 'EntryPoint',
-        urlTemplate: `${url}/searches?keyword={search_term_string}`
+        // サイト内の検索フォームは全て `text` を送る。ここだけ `keyword` になっており、
+        // 検索エンジン経由で来た人は空の検索ページに着地していた。
+        urlTemplate: `${url}/searches?text={search_term_string}`
       },
       'query-input': 'required name=search_term_string'
     }

--- a/src/app/searches/client_index.tsx
+++ b/src/app/searches/client_index.tsx
@@ -7,190 +7,136 @@ declare global {
 }
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { Blog } from '../../../libs/notion';
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { BlogProps } from '../../../libs/notion';
-import Image from 'next/image';
 import { Search, ArrowRight } from 'lucide-react';
-
-const HighlightText = ({ text: content, query }: { text: string; query: string | null }) => {
-  if (!query) return <>{content}</>;
-  const parts = content.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'));
-  return <>{parts.map((part, i) =>
-    part.toLowerCase() === query.toLowerCase()
-      ? <mark key={i} className='bg-yellow-200 dark:bg-yellow-800/50 text-inherit rounded px-0.5'>{part}</mark>
-      : part
-  )}</>;
-};
+import { PostCard } from '@/components/PostCard/PostCard';
+import { parseQuery, searchBlogs, MATCH_LABELS } from '@/lib/search';
 
 export const ClientIndex = ({ contents }: BlogProps) => {
   const searchParams = useSearchParams();
-  const text = searchParams.get('text');
-  const [blogContents, setBlogContents] = useState<Blog[] | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  // トップの構造化データが `keyword` を送っていた時期があるので両方受ける
+  const text = searchParams.get('text') ?? searchParams.get('keyword') ?? '';
+  const [draft, setDraft] = useState(text);
+
+  // 戻る/進むやサジェストからの遷移でURLだけ変わったとき、入力欄も追随させる
+  useEffect(() => {
+    setDraft(text);
+  }, [text]);
+
+  const terms = useMemo(() => parseQuery(text), [text]);
+  // 全件を舐めるだけなので同期で済む。以前は useEffect + ローディング状態で
+  // 非同期処理のように扱っていたが、待つものが何もなかった。
+  const hits = useMemo(() => (text ? searchBlogs(contents, text) : null), [contents, text]);
 
   useEffect(() => {
-    const fetchData = async () => {
-      setIsLoading(true);
-      try {
-        if (text) {
-          const filteredContents = contents.filter((content) =>
-            content.body.toLowerCase().includes(text.toLowerCase()) ||
-            content.title.toLowerCase().includes(text.toLowerCase()) ||
-            content.tags?.some(tag => tag.name.toLowerCase().includes(text.toLowerCase())) ||
-            content.category?.name.toLowerCase().includes(text.toLowerCase())
-          ).sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-          setBlogContents(filteredContents);
-          if (typeof window !== 'undefined' && window.gtag) {
-            window.gtag('event', 'search', {
-              search_term: text,
-              event_category: 'Search',
-              event_label: filteredContents.length === 0 ? 'zero_results' : 'has_results',
-              value: filteredContents.length,
-            });
-          }
-        } else {
-          setBlogContents(null);
-        }
-      } catch (error) {
-        console.error('Error fetching data:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+    if (!hits || !text) return;
+    if (typeof window !== 'undefined' && window.gtag) {
+      window.gtag('event', 'search', {
+        search_term: text,
+        event_category: 'Search',
+        event_label: hits.length === 0 ? 'zero_results' : 'has_results',
+        value: hits.length,
+      });
+    }
+  }, [hits, text]);
 
-    fetchData();
-  }, [text, contents]);
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = draft.trim();
+    router.push(trimmed ? `/searches?text=${encodeURIComponent(trimmed)}` : '/searches');
+  };
 
   return (
     <div className='min-h-screen px-4'>
-      {/* Search Header */}
       <div className='max-w-3xl mx-auto mb-8 pt-4'>
-        <h1 className='text-2xl font-bold text-slate-900 dark:text-slate-100 mb-2'>
-          検索結果
-        </h1>
+        <h1 className='text-2xl font-bold text-slate-900 dark:text-slate-100 mb-4'>検索</h1>
 
-        {text ? (
-          <p className='text-slate-600 dark:text-slate-400'>
+        {/* 検索ページ自体に入力欄が無く、「上部の検索フォームから」という
+            案内だけがあった。ヘッダーにあるのは検索アイコンで、フォームではない。 */}
+        <form onSubmit={submit} role='search' className='flex items-center gap-2'>
+          <input
+            type='search'
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder='キーワードで記事を検索'
+            aria-label='検索キーワード'
+            className='flex-1 px-4 py-2.5 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder-slate-400 border border-slate-200 dark:border-slate-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400'
+          />
+          <button
+            type='submit'
+            className='px-4 py-2.5 text-sm font-medium bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 rounded-lg hover:bg-slate-700 dark:hover:bg-slate-300 transition-colors'
+          >
+            検索
+          </button>
+        </form>
+        <p className='mt-2 text-xs text-slate-500 dark:text-slate-400'>
+          スペース区切りで複数のキーワードを指定すると、すべてを含む記事を探します。
+          タイトル・概要・タグ・カテゴリが対象です。
+        </p>
+
+        {text && (
+          <p className='mt-4 text-slate-600 dark:text-slate-400'>
             「<span className='font-medium text-slate-900 dark:text-slate-100'>{text}</span>」の検索結果
-            {blogContents && (
-              <span className='ml-2 text-sm'>
-                ({blogContents.length}件)
-              </span>
-            )}
-          </p>
-        ) : (
-          <p className='text-slate-500 dark:text-slate-400'>
-            検索キーワードを入力してください
+            {hits && <span className='ml-2 text-sm'>({hits.length}件)</span>}
           </p>
         )}
       </div>
 
-      {/* Loading State */}
-      {isLoading && (
-        <div className='flex justify-center items-center py-12'>
-          <div className='w-6 h-6 border-2 border-slate-300 border-t-slate-600 dark:border-slate-600 dark:border-t-slate-300 rounded-full animate-spin' />
-        </div>
-      )}
-
-      {/* Search Results - same layout as Index component */}
       <div aria-live='polite' aria-atomic='true' className='sr-only'>
-        {!isLoading && blogContents && `${blogContents.length}件の検索結果`}
+        {hits && `${hits.length}件の検索結果`}
       </div>
-      {!isLoading && blogContents && blogContents.length > 0 ? (
-        <div className='max-w-3xl mx-auto px-4'>
+
+      {hits && hits.length > 0 ? (
+        <div className='max-w-3xl mx-auto'>
           <div className='space-y-4'>
-            {blogContents.map((blog) => (
-              <article key={blog.id} className='group'>
-                <Link href={`/blogs/${blog.id}`} className='block'>
-                  <div className='flex gap-4 p-4 h-[140px] sm:h-[150px] rounded-xl bg-white dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 shadow-sm hover:shadow-lg hover:border-slate-200 dark:hover:border-slate-600 hover:-translate-y-0.5 transition-all duration-300 overflow-hidden'>
-                    {/* サムネイル画像 */}
-                    <div className='flex-shrink-0 relative w-24 sm:w-32 h-full rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-700'>
-                      <Image
-                        src={blog.eyecatch?.url || '/images/no_image_generated.png'}
-                        alt=''
-                        fill
-                        sizes='(max-width: 640px) 96px, 128px'
-                        className='object-cover group-hover:scale-105 transition-transform duration-300'
-                      />
-                      {Date.now() - new Date(blog.createdAt).getTime() < 72 * 60 * 60 * 1000 && (
-                        <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-red-500 text-white rounded'>
-                          NEW
-                        </span>
-                      )}
-                    </div>
-
-                    {/* コンテンツ */}
-                    <div className='flex-1 min-w-0 flex flex-col justify-between py-0.5'>
-                      <h2 className='text-sm sm:text-base font-semibold text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2 leading-snug'>
-                        <HighlightText text={blog.title} query={text} />
-                      </h2>
-
-                      <div className='space-y-1.5'>
-                        <div className='flex items-center gap-1.5 text-[11px] text-slate-500 dark:text-slate-400'>
-                          <time className='whitespace-nowrap' title={new Date(blog.createdAt).toLocaleDateString('ja-JP')}>
-                            {new Date(blog.createdAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' })}
-                          </time>
-                          {blog.category && (
-                            <>
-                              <span className='text-slate-300 dark:text-slate-600'>|</span>
-                              <span className='whitespace-nowrap truncate'>{blog.category.name}</span>
-                            </>
-                          )}
-                        </div>
-
-                        {blog.tags && blog.tags.length > 0 && (
-                          <div className='flex gap-1.5 overflow-hidden h-4'>
-                            {blog.tags.slice(0, 3).map((tag) => (
-                              <span
-                                key={tag.id}
-                                className='text-[11px] text-slate-500 dark:text-slate-400 whitespace-nowrap'
-                              >
-                                #{tag.name}
-                              </span>
-                            ))}
-                            {blog.tags.length > 3 && (
-                              <span className='text-[11px] text-slate-500 dark:text-slate-400'>...</span>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </Link>
-              </article>
+            {hits.map(({ blog, matched }) => (
+              <PostCard
+                key={blog.id}
+                blog={blog}
+                terms={terms}
+                footer={
+                  // なぜこの記事が出てきたのかを示す。
+                  // 一致箇所が本文でないことも多く、示さないと結果が唐突に見える
+                  <p className='pt-1 text-[11px] text-slate-400 dark:text-slate-500'>
+                    {matched.map((m) => MATCH_LABELS[m]).join('・')}に一致
+                  </p>
+                }
+              />
             ))}
           </div>
         </div>
-      ) : !isLoading && blogContents && blogContents.length === 0 ? (
+      ) : hits ? (
         <div className='max-w-3xl mx-auto text-center py-16'>
-          <Search className='w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-4' />
-          <h3 className='text-lg font-medium text-slate-900 dark:text-slate-100 mb-2'>
+          <Search className='w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-4' aria-hidden='true' />
+          <h2 className='text-lg font-medium text-slate-900 dark:text-slate-100 mb-2'>
             検索結果が見つかりませんでした
-          </h3>
+          </h2>
           <p className='text-slate-500 dark:text-slate-400 mb-6'>
-            「{text}」に一致する記事がありません。別のキーワードで検索してください。
+            「{text}」に一致する記事がありません。
+            {terms.length > 1 && 'キーワードを減らすと見つかるかもしれません。'}
           </p>
           <Link
             href='/blogs/page/1'
             className='inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg transition-colors'
           >
             ブログ一覧を見る
-            <ArrowRight className='w-4 h-4' />
+            <ArrowRight className='w-4 h-4' aria-hidden='true' />
           </Link>
         </div>
-      ) : !text ? (
+      ) : (
         <div className='max-w-3xl mx-auto text-center py-16'>
-          <Search className='w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-4' />
-          <h3 className='text-lg font-medium text-slate-900 dark:text-slate-100 mb-2'>
+          <Search className='w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-4' aria-hidden='true' />
+          <h2 className='text-lg font-medium text-slate-900 dark:text-slate-100 mb-2'>
             キーワードを入力してください
-          </h3>
+          </h2>
           <p className='text-slate-500 dark:text-slate-400'>
-            上部の検索フォームからキーワードを入力して、記事を検索できます。
+            上の検索フォームにキーワードを入力すると、記事を探せます。
           </p>
         </div>
-      ) : null}
+      )}
     </div>
   );
 };

--- a/src/app/searches/page.tsx
+++ b/src/app/searches/page.tsx
@@ -3,18 +3,32 @@ import ClientIndex from './client_index';
 import { getList } from '../../../libs/notion';
 import { Metadata } from 'next';
 import { WithSidebar } from '@/components/WithSidebar/WithSidebar';
+import { isPublic } from '@/lib/blog';
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+// これが無いとビルド時に一度だけ getList() が走り、その結果が静的に焼き込まれる。
+// 新しく公開した記事は次のデプロイまで検索に出てこなかった。
+export const runtime = 'edge';
+
 export default async function StaticPage() {
-  const { contents } = await getList();
+  const { contents } = await getList().catch(() => ({ contents: [], totalCount: 0, offset: 0, limit: 0 }));
 
   return (
     <WithSidebar>
-      <Suspense fallback={<div className='animate-pulse space-y-4 max-w-3xl mx-auto px-4'>{[1,2,3].map(i => <div key={i} className='h-[140px] bg-slate-200 dark:bg-slate-700 rounded-xl' />)}</div>}>
-        <ClientIndex contents={contents} />
+      <Suspense
+        fallback={
+          <div className='animate-pulse space-y-4 max-w-3xl mx-auto px-4'>
+            {[1, 2, 3].map((i) => (
+              <div key={i} className='h-[140px] bg-slate-200 dark:bg-slate-700 rounded-xl' />
+            ))}
+          </div>
+        }
+      >
+        {/* 一覧に出していないPF記事が検索でだけ出てくると導線が破綻する */}
+        <ClientIndex contents={contents.filter(isPublic)} />
       </Suspense>
     </WithSidebar>
   );

--- a/src/components/Bookmark/BookmarkButton.tsx
+++ b/src/components/Bookmark/BookmarkButton.tsx
@@ -1,29 +1,22 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { Bookmark, BookmarkCheck } from 'lucide-react';
-
-const STORAGE_KEY = 'kt-tech-bookmarks';
+import { addBookmark, removeBookmark, isBookmarked as checkBookmarked } from '@/lib/bookmarks';
 
 export const BookmarkButton = ({ articleId, title }: { articleId: string; title: string }) => {
   const [isBookmarked, setIsBookmarked] = useState(false);
 
   useEffect(() => {
-    try {
-      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as { id: string }[];
-      setIsBookmarked(stored.some(b => b.id === articleId));
-    } catch {}
+    setIsBookmarked(checkBookmarked(articleId));
   }, [articleId]);
 
   const toggle = () => {
     try {
-      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as { id: string; title: string; savedAt: string }[];
       if (isBookmarked) {
-        const filtered = stored.filter(b => b.id !== articleId);
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+        removeBookmark(articleId);
         setIsBookmarked(false);
       } else {
-        stored.unshift({ id: articleId, title, savedAt: new Date().toISOString() });
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(stored.slice(0, 50)));
+        addBookmark({ id: articleId, title, savedAt: new Date().toISOString() });
         setIsBookmarked(true);
       }
     } catch {}
@@ -39,7 +32,7 @@ export const BookmarkButton = ({ articleId, title }: { articleId: string; title:
       }`}
       aria-label={isBookmarked ? 'ブックマークを解除' : 'ブックマークに追加'}
     >
-      {isBookmarked ? <BookmarkCheck className='w-3.5 h-3.5' /> : <Bookmark className='w-3.5 h-3.5' />}
+      {isBookmarked ? <BookmarkCheck className='w-3.5 h-3.5' aria-hidden='true' /> : <Bookmark className='w-3.5 h-3.5' aria-hidden='true' />}
       {isBookmarked ? '保存済み' : 'あとで読む'}
     </button>
   );

--- a/src/components/Bookmark/BookmarkList.tsx
+++ b/src/components/Bookmark/BookmarkList.tsx
@@ -1,0 +1,82 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Bookmark as BookmarkIcon, Trash2, ArrowRight } from 'lucide-react';
+import { getBookmarks, removeBookmark, type Bookmark } from '@/lib/bookmarks';
+
+/**
+ * 保存した記事の一覧。
+ *
+ * 「あとで読む」で保存はできるのに見返す画面がなく、
+ * 保存した記事に二度とたどり着けない状態だった。
+ */
+export const BookmarkList = () => {
+  // null は「まだ localStorage を読んでいない」。
+  // 初期値を [] にすると、読み込む前に一瞬「まだありません」が出る。
+  const [bookmarks, setBookmarks] = useState<Bookmark[] | null>(null);
+
+  useEffect(() => {
+    setBookmarks(getBookmarks());
+  }, []);
+
+  const remove = (id: string) => {
+    removeBookmark(id);
+    setBookmarks(getBookmarks());
+  };
+
+  if (bookmarks === null) {
+    return (
+      <div className='space-y-3 px-2' aria-hidden='true'>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className='h-16 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800' />
+        ))}
+      </div>
+    );
+  }
+
+  if (bookmarks.length === 0) {
+    return (
+      <div className='py-16 text-center'>
+        <BookmarkIcon className='mx-auto mb-4 h-12 w-12 text-slate-300 dark:text-slate-600' aria-hidden='true' />
+        <h2 className='mb-2 text-lg font-medium text-slate-900 dark:text-slate-100'>保存した記事はありません</h2>
+        <p className='mb-6 text-slate-500 dark:text-slate-400'>
+          記事ページの「あとで読む」から保存すると、ここに並びます。
+        </p>
+        <Link
+          href='/blogs/page/1'
+          className='inline-flex items-center gap-2 rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'
+        >
+          ブログ一覧を見る
+          <ArrowRight className='h-4 w-4' aria-hidden='true' />
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <ul className='space-y-3 px-2'>
+      {bookmarks.map((bookmark) => (
+        <li
+          key={bookmark.id}
+          className='flex items-center gap-3 rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800'
+        >
+          <Link href={`/blogs/${bookmark.id}`} className='min-w-0 flex-1 group'>
+            <span className='block truncate font-semibold text-slate-900 group-hover:text-blue-600 dark:text-slate-100 dark:group-hover:text-blue-400'>
+              {bookmark.title}
+            </span>
+            <time dateTime={bookmark.savedAt} className='mt-1 block text-xs text-slate-400 dark:text-slate-500'>
+              {bookmark.savedAt.slice(0, 10).replace(/-/g, '/')} に保存
+            </time>
+          </Link>
+          <button
+            onClick={() => remove(bookmark.id)}
+            aria-label={`「${bookmark.title}」を保存から削除`}
+            className='shrink-0 rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-red-600 dark:hover:bg-slate-700 dark:hover:text-red-400'
+          >
+            <Trash2 className='h-4 w-4' aria-hidden='true' />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -90,6 +90,11 @@ export const Footer = () => {
                 </Link>
               </li>
               <li>
+                <Link href='/bookmarks' className='text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 transition-colors'>
+                  Bookmarks
+                </Link>
+              </li>
+              <li>
                 <Link href='/searches' className='text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 transition-colors'>
                   Search
                 </Link>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
 import { ModeToggle } from '../ModeToggle/modeToggle';
-import { Menu, X, Home, BookOpen, User, Search, Github, Library } from 'lucide-react';
+import { Menu, X, Home, BookOpen, User, Search, Github, Library, Bookmark } from 'lucide-react';
 import { SearchModal } from '../SearchModal/SearchModal';
 import { useDialog } from '@/lib/useDialog';
 
@@ -173,6 +173,21 @@ export const Header = () => {
                 <Search className='w-5 h-5 text-slate-400 dark:text-slate-500' aria-hidden='true' />
                 <span className='text-lg font-medium'>Search</span>
               </button>
+              {/* 「あとで読む」で保存した記事の置き場。
+                  デスクトップのヘッダーは項目を増やしたくないのでモバイルとフッターに置く */}
+              <Link
+                href='/bookmarks'
+                onClick={closeMenu}
+                aria-current={isActive('/bookmarks') ? 'page' : undefined}
+                className={`flex items-center gap-4 px-4 py-4 rounded-xl transition-colors ${
+                  isActive('/bookmarks')
+                    ? 'bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-100'
+                    : 'text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800'
+                }`}
+              >
+                <Bookmark className='w-5 h-5 text-slate-400 dark:text-slate-500' aria-hidden='true' />
+                <span className='text-lg font-medium'>Bookmarks</span>
+              </Link>
             </nav>
 
             {/* Bottom section */}

--- a/src/components/Index/Index.tsx
+++ b/src/components/Index/Index.tsx
@@ -1,20 +1,7 @@
 'use client';
 import { BlogProps } from '../../../libs/notion';
-import Link from 'next/link';
-import Image from 'next/image';
 import { FadeIn } from '../FadeIn/FadeIn';
-import { Library } from 'lucide-react';
-
-const timeAgo = (date: string) => {
-  const diff = Date.now() - new Date(date).getTime();
-  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-  if (days === 0) return '今日';
-  if (days === 1) return '昨日';
-  if (days < 7) return `${days}日前`;
-  if (days < 30) return `${Math.floor(days / 7)}週間前`;
-  if (days < 365) return `${Math.floor(days / 30)}ヶ月前`;
-  return `${Math.floor(days / 365)}年前`;
-};
+import { PostCard } from '../PostCard/PostCard';
 
 export const Index = ({ contents }: BlogProps) => {
   return (
@@ -22,95 +9,7 @@ export const Index = ({ contents }: BlogProps) => {
       <div className='space-y-4'>
         {contents.map((blog) => (
           <FadeIn key={blog.id}>
-          <article className='group'>
-            <Link href={`/blogs/${blog.id}`} className='block'>
-              <div className='flex gap-4 p-4 h-[140px] sm:h-[150px] rounded-xl bg-white dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 shadow-sm hover:shadow-lg hover:border-slate-200 dark:hover:border-slate-600 hover:-translate-y-0.5 transition-all duration-300 overflow-hidden'>
-                {/* サムネイル画像 */}
-                <div className='flex-shrink-0 relative w-24 sm:w-32 h-full rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-700'>
-                  <Image
-                    src={blog.eyecatch?.url || '/images/no_image_generated.png'}
-                    alt=''
-                    fill
-                    // 実表示は96〜128px。sizes がないと 100vw 扱いになり原寸が配信される
-                    sizes='(max-width: 640px) 96px, 128px'
-                    className='object-cover group-hover:scale-105 transition-transform duration-300'
-                  />
-                  {Date.now() - new Date(blog.createdAt).getTime() < 72 * 60 * 60 * 1000 ? (
-                    <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-red-500 text-white rounded'>
-                      NEW
-                    </span>
-                  ) : blog.updatedAt && new Date(blog.updatedAt).getTime() - new Date(blog.createdAt).getTime() > 24 * 60 * 60 * 1000 && Date.now() - new Date(blog.updatedAt).getTime() < 7 * 24 * 60 * 60 * 1000 ? (
-                    <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-blue-500 text-white rounded'>
-                      更新
-                    </span>
-                  ) : null}
-                </div>
-
-                {/* コンテンツ */}
-                <div className='flex-1 min-w-0 flex flex-col justify-between py-0.5'>
-                  <div className='min-w-0'>
-                    {/* 連載バッジ。一覧の時点で「これは連載の一部」と分かると、
-                        途中の回を単発記事だと思って読み始めるのを防げる */}
-                    {blog.series && (
-                      <span className='mb-1 flex items-center gap-1 text-[10px] font-semibold text-blue-600 dark:text-blue-400'>
-                        <Library className='h-3 w-3 shrink-0' aria-hidden='true' />
-                        <span className='truncate'>{blog.series.name}</span>
-                        {blog.series.order > 0 && (
-                          <span className='shrink-0 tabular-nums text-slate-400 dark:text-slate-500'>
-                            #{blog.series.order}
-                          </span>
-                        )}
-                      </span>
-                    )}
-                    <h2 className='text-sm sm:text-base font-semibold text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2 leading-snug'>
-                      {blog.title}
-                    </h2>
-                  </div>
-
-                  <div className='space-y-1.5'>
-                    <div className='flex items-center gap-1.5 text-[11px] text-slate-500 dark:text-slate-400'>
-                      {/* 相対表記だと「いつの記事か」が直感的に分かる。技術記事は鮮度が重要 */}
-                      <time
-                        className='whitespace-nowrap'
-                        dateTime={blog.createdAt}
-                        title={new Date(blog.createdAt).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })}
-                      >
-                        {timeAgo(blog.createdAt)}
-                      </time>
-                      {blog.body && blog.body.length > 0 && (
-                        <>
-                          <span className='text-slate-300 dark:text-slate-600'>|</span>
-                          <span className='whitespace-nowrap'>{Math.max(1, Math.ceil(blog.body.length / 600))}分で読める</span>
-                        </>
-                      )}
-                      {blog.category && (
-                        <>
-                          <span className='text-slate-300 dark:text-slate-600'>|</span>
-                          <span className='whitespace-nowrap truncate'>{blog.category.name}</span>
-                        </>
-                      )}
-                    </div>
-
-                    {blog.tags && blog.tags.length > 0 && (
-                      <div className='flex gap-1.5 overflow-hidden h-4'>
-                        {blog.tags.slice(0, 3).map((tag) => (
-                          <span
-                            key={tag.id}
-                            className='text-[11px] text-slate-500 dark:text-slate-400 whitespace-nowrap'
-                          >
-                            #{tag.name}
-                          </span>
-                        ))}
-                        {blog.tags.length > 3 && (
-                          <span className='text-[11px] text-slate-500 dark:text-slate-400'>...</span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </Link>
-          </article>
+            <PostCard blog={blog} />
           </FadeIn>
         ))}
       </div>

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -1,0 +1,161 @@
+'use client';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Library } from 'lucide-react';
+import type { Blog } from '../../../libs/notion';
+
+/**
+ * 記事一覧のカード。
+ *
+ * 一覧（Index）と検索結果でほぼ同じマークアップが丸ごと複製されており、
+ * 「連載バッジを足す」「抜粋を出す」といった変更のたびに
+ * 二重に直す必要があった（そして片方が取り残されていた）。
+ */
+
+const timeAgo = (date: string) => {
+  const diff = Date.now() - new Date(date).getTime();
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  if (days === 0) return '今日';
+  if (days === 1) return '昨日';
+  if (days < 7) return `${days}日前`;
+  if (days < 30) return `${Math.floor(days / 7)}週間前`;
+  if (days < 365) return `${Math.floor(days / 30)}ヶ月前`;
+  return `${Math.floor(days / 365)}年前`;
+};
+
+const NEW_WINDOW_MS = 72 * 60 * 60 * 1000;
+const UPDATED_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const MEANINGFUL_UPDATE_MS = 24 * 60 * 60 * 1000;
+
+/** キーワードに一致した箇所を目立たせる */
+export const HighlightText = ({ text, terms }: { text: string; terms?: string[] }) => {
+  if (!terms || terms.length === 0) return <>{text}</>;
+  const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).filter(Boolean);
+  if (escaped.length === 0) return <>{text}</>;
+  const parts = text.split(new RegExp(`(${escaped.join('|')})`, 'gi'));
+  const lowered = terms.map((t) => t.toLowerCase());
+  return (
+    <>
+      {parts.map((part, i) =>
+        lowered.includes(part.toLowerCase()) ? (
+          <mark key={i} className='bg-yellow-200 dark:bg-yellow-800/50 text-inherit rounded px-0.5'>
+            {part}
+          </mark>
+        ) : (
+          part
+        )
+      )}
+    </>
+  );
+};
+
+type Props = {
+  blog: Blog;
+  /** 検索結果でハイライトする語 */
+  terms?: string[];
+  /** カードの下に添える補足（検索結果の一致箇所など） */
+  footer?: React.ReactNode;
+};
+
+export const PostCard = ({ blog, terms, footer }: Props) => {
+  const now = Date.now();
+  const isNew = now - new Date(blog.createdAt).getTime() < NEW_WINDOW_MS;
+  const isUpdated =
+    !isNew &&
+    Boolean(blog.updatedAt) &&
+    new Date(blog.updatedAt).getTime() - new Date(blog.createdAt).getTime() > MEANINGFUL_UPDATE_MS &&
+    now - new Date(blog.updatedAt).getTime() < UPDATED_WINDOW_MS;
+
+  return (
+    <article className='group'>
+      <Link href={`/blogs/${blog.id}`} className='block'>
+        {/* 固定高をやめ、内容に応じて伸びるようにした。
+            短いタイトルでは余白が間延びし、長いタイトルは切れていた。 */}
+        <div className='flex gap-4 p-4 rounded-xl bg-white dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 shadow-sm hover:shadow-lg hover:border-slate-200 dark:hover:border-slate-600 hover:-translate-y-0.5 transition-all duration-300'>
+          <div className='flex-shrink-0 relative w-24 sm:w-32 aspect-[4/3] rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-700'>
+            <Image
+              src={blog.eyecatch?.url || '/images/no_image_generated.png'}
+              alt=''
+              fill
+              // 実表示は96〜128px。sizes がないと 100vw 扱いになり原寸が配信される
+              sizes='(max-width: 640px) 96px, 128px'
+              className='object-cover group-hover:scale-105 transition-transform duration-300'
+            />
+            {isNew ? (
+              <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-red-500 text-white rounded'>
+                NEW
+              </span>
+            ) : isUpdated ? (
+              <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-blue-500 text-white rounded'>
+                更新
+              </span>
+            ) : null}
+          </div>
+
+          <div className='flex-1 min-w-0 space-y-1.5'>
+            {/* 連載バッジ。一覧の時点で「これは連載の一部」と分かると、
+                途中の回を単発記事だと思って読み始めるのを防げる */}
+            {blog.series && (
+              <span className='flex items-center gap-1 text-[10px] font-semibold text-blue-600 dark:text-blue-400'>
+                <Library className='h-3 w-3 shrink-0' aria-hidden='true' />
+                <span className='truncate'>{blog.series.name}</span>
+                {blog.series.order > 0 && (
+                  <span className='shrink-0 tabular-nums text-slate-400 dark:text-slate-500'>
+                    #{blog.series.order}
+                  </span>
+                )}
+              </span>
+            )}
+
+            <h2 className='text-sm sm:text-base font-semibold text-slate-800 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2 leading-snug'>
+              <HighlightText text={blog.title} terms={terms} />
+            </h2>
+
+            {/* 抜粋。タイトルだけでは中身が判断できず、一覧で開くかどうかを決められなかった */}
+            {blog.ogpDescription && (
+              <p className='text-xs text-slate-500 dark:text-slate-400 line-clamp-2 leading-relaxed'>
+                <HighlightText text={blog.ogpDescription} terms={terms} />
+              </p>
+            )}
+
+            <div className='flex items-center gap-1.5 text-[11px] text-slate-500 dark:text-slate-400'>
+              {/* 相対表記だと「いつの記事か」が直感的に分かる。技術記事は鮮度が重要 */}
+              <time
+                className='whitespace-nowrap'
+                dateTime={blog.createdAt}
+                title={new Date(blog.createdAt).toLocaleDateString('ja-JP', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              >
+                {timeAgo(blog.createdAt)}
+              </time>
+              {blog.category && (
+                <>
+                  <span className='text-slate-300 dark:text-slate-600'>|</span>
+                  <span className='whitespace-nowrap truncate'>{blog.category.name}</span>
+                </>
+              )}
+            </div>
+
+            {blog.tags && blog.tags.length > 0 && (
+              <div className='flex flex-wrap gap-1.5'>
+                {blog.tags.slice(0, 3).map((tag) => (
+                  <span key={tag.id} className='text-[11px] text-slate-500 dark:text-slate-400 whitespace-nowrap'>
+                    #{tag.name}
+                  </span>
+                ))}
+                {blog.tags.length > 3 && (
+                  <span className='text-[11px] text-slate-500 dark:text-slate-400'>...</span>
+                )}
+              </div>
+            )}
+
+            {footer}
+          </div>
+        </div>
+      </Link>
+    </article>
+  );
+};

--- a/src/components/PostNavigation/PostNavigation.tsx
+++ b/src/components/PostNavigation/PostNavigation.tsx
@@ -48,6 +48,15 @@ export const PostNavigation = ({ currentId, allPosts }: PostNavigationProps) => 
           </Link>
         ) : <div />}
       </div>
+      {/* j / k のショートカットはどこにも書かれておらず、誰も気づけなかった。
+          hover のない端末（=キーボードが無いことが多い）では出さない。 */}
+      <p className='mt-4 hidden text-center text-[11px] text-slate-400 dark:text-slate-500 [@media(hover:hover)]:block'>
+        キーボードの
+        <kbd className='mx-1 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] dark:bg-slate-800'>j</kbd>
+        で次の記事、
+        <kbd className='mx-1 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] dark:bg-slate-800'>k</kbd>
+        で前の記事に移動できます
+      </p>
     </nav>
   );
 };

--- a/src/components/SearchModal/SearchModal.tsx
+++ b/src/components/SearchModal/SearchModal.tsx
@@ -1,19 +1,55 @@
 'use client';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { Search, X } from 'lucide-react';
+import { Search, X, Loader2 } from 'lucide-react';
 import { useDialog } from '@/lib/useDialog';
+import { parseQuery } from '@/lib/search';
 
 type Props = { isOpen: boolean; onClose: () => void };
+
+type IndexEntry = {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  category: string;
+  series: string;
+};
+
+const MAX_SUGGESTIONS = 6;
+
+/** モーダル用の簡易マッチ。検索ページ本体と同じく全ての語を含むことを条件にする */
+function suggest(index: IndexEntry[], raw: string): IndexEntry[] {
+  const terms = parseQuery(raw);
+  if (terms.length === 0) return [];
+  return index
+    .filter((entry) => {
+      const haystack = [entry.title, entry.description, entry.category, entry.series, ...entry.tags]
+        .join(' ')
+        .toLowerCase();
+      return terms.every((t) => haystack.includes(t));
+    })
+    .sort((a, b) => {
+      // タイトルに含まれるものを優先。概要だけの一致は関連が薄いことが多い
+      const at = terms.every((t) => a.title.toLowerCase().includes(t)) ? 0 : 1;
+      const bt = terms.every((t) => b.title.toLowerCase().includes(t)) ? 0 : 1;
+      return at - bt;
+    })
+    .slice(0, MAX_SUGGESTIONS);
+}
 
 export const SearchModal = ({ isOpen, onClose }: Props) => {
   const [query, setQuery] = useState('');
   const [isMac, setIsMac] = useState(true);
+  const [index, setIndex] = useState<IndexEntry[] | null>(null);
+  const [isLoadingIndex, setLoadingIndex] = useState(false);
+  const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
 
   const close = useCallback(() => {
     setQuery('');
+    setActive(0);
     onClose();
   }, [onClose]);
 
@@ -28,16 +64,61 @@ export const SearchModal = ({ isOpen, onClose }: Props) => {
     if (isOpen) inputRef.current?.focus();
   }, [isOpen]);
 
-  const handleSearch = () => {
+  // インデックスは最初にモーダルを開いたときだけ取りに行く。
+  // 全ページで先読みすると、検索を使わない人にも転送コストがかかる。
+  useEffect(() => {
+    if (!isOpen || index !== null || isLoadingIndex) return;
+    setLoadingIndex(true);
+    fetch('/api/search-index')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setIndex(Array.isArray(data) ? data : []))
+      .catch(() => setIndex([]))
+      .finally(() => setLoadingIndex(false));
+  }, [isOpen, index, isLoadingIndex]);
+
+  const suggestions = useMemo(() => (index ? suggest(index, query) : []), [index, query]);
+
+  useEffect(() => {
+    setActive(0);
+  }, [query]);
+
+  const goToSearchPage = useCallback(() => {
     if (query.trim()) {
       router.push(`/searches?text=${encodeURIComponent(query.trim())}`);
       close();
     }
-  };
+  }, [query, router, close]);
+
+  const openArticle = useCallback(
+    (id: string) => {
+      router.push(`/blogs/${id}`);
+      close();
+    },
+    [router, close]
+  );
 
   if (!isOpen) return null;
 
   const modKey = isMac ? '⌘' : 'Ctrl+';
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // IMEの変換確定のEnterで検索が走らないようにする。
+    // これが無いと日本語を入力しても未確定の読みで検索されてしまう。
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      // 候補の下に「すべての結果を見る」があるので長さ+1で回す
+      setActive((i) => (i + 1) % (suggestions.length + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((i) => (i - 1 + suggestions.length + 1) % (suggestions.length + 1));
+    } else if (e.key === 'Enter') {
+      if (active < suggestions.length) openArticle(suggestions[active].id);
+      else goToSearchPage();
+    }
+  };
+
+  const activeId = active < suggestions.length ? `search-option-${active}` : 'search-option-all';
 
   return (
     <div className='fixed inset-0 z-[100] flex items-start justify-center pt-[20vh]'>
@@ -58,20 +139,77 @@ export const SearchModal = ({ isOpen, onClose }: Props) => {
             onChange={(e) => setQuery(e.target.value)}
             placeholder='記事を検索...'
             aria-label='検索キーワード'
+            role='combobox'
+            aria-expanded={query.trim().length > 0}
+            aria-controls='search-suggestions'
+            aria-activedescendant={query.trim() ? activeId : undefined}
+            autoComplete='off'
             className='flex-1 py-3.5 bg-transparent text-slate-900 dark:text-slate-100 placeholder:text-slate-400 outline-none text-base'
-            onKeyDown={(e) => {
-              // IMEの変換確定のEnterで検索が走らないようにする。
-              // これが無いと日本語を入力しても未確定の読みで検索されてしまう。
-              if (e.key === 'Enter' && !e.nativeEvent.isComposing) handleSearch();
-            }}
+            onKeyDown={onKeyDown}
           />
-          <button onClick={close} aria-label='閉じる' className='p-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'>
+          {isLoadingIndex && <Loader2 className='w-4 h-4 text-slate-400 animate-spin' aria-hidden='true' />}
+          <button
+            onClick={close}
+            aria-label='閉じる'
+            className='p-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'
+          >
             <X className='w-4 h-4' aria-hidden='true' />
           </button>
         </div>
-        <div className='px-4 py-2.5 flex items-center gap-4 text-[11px] text-slate-500 dark:text-slate-400'>
+
+        {/* 候補表示。以前は Enter を押して検索ページに飛ぶまで何も分からず、
+            キーワードが的外れかどうかも判断できなかった。 */}
+        {query.trim() && (
+          <ul id='search-suggestions' role='listbox' aria-label='検索候補' className='max-h-80 overflow-y-auto'>
+            {suggestions.map((entry, i) => (
+              <li key={entry.id}>
+                <button
+                  id={`search-option-${i}`}
+                  role='option'
+                  aria-selected={i === active}
+                  onClick={() => openArticle(entry.id)}
+                  onMouseEnter={() => setActive(i)}
+                  className={`block w-full px-4 py-2.5 text-left ${
+                    i === active ? 'bg-slate-100 dark:bg-slate-800' : ''
+                  }`}
+                >
+                  <span className='block truncate text-sm text-slate-800 dark:text-slate-100'>{entry.title}</span>
+                  {(entry.category || entry.tags.length > 0) && (
+                    <span className='mt-0.5 block truncate text-[11px] text-slate-500 dark:text-slate-400'>
+                      {[entry.category, ...entry.tags.slice(0, 3).map((t) => `#${t}`)].filter(Boolean).join(' ')}
+                    </span>
+                  )}
+                </button>
+              </li>
+            ))}
+            {index !== null && suggestions.length === 0 && (
+              <li className='px-4 py-3 text-sm text-slate-500 dark:text-slate-400'>
+                一致する記事が見つかりません
+              </li>
+            )}
+            <li className='border-t border-slate-200 dark:border-slate-700'>
+              <button
+                id='search-option-all'
+                role='option'
+                aria-selected={active === suggestions.length}
+                onClick={goToSearchPage}
+                onMouseEnter={() => setActive(suggestions.length)}
+                className={`block w-full px-4 py-2.5 text-left text-sm text-slate-600 dark:text-slate-300 ${
+                  active === suggestions.length ? 'bg-slate-100 dark:bg-slate-800' : ''
+                }`}
+              >
+                「{query.trim()}」の検索結果をすべて見る
+              </button>
+            </li>
+          </ul>
+        )}
+
+        <div className='px-4 py-2.5 flex items-center gap-4 text-[11px] text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700'>
           <span>
-            <kbd className='px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-[10px]'>Enter</kbd> で検索
+            <kbd className='px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-[10px]'>↑↓</kbd> で選択
+          </span>
+          <span>
+            <kbd className='px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-[10px]'>Enter</kbd> で開く
           </span>
           <span>
             <kbd className='px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-[10px]'>Esc</kbd> で閉じる

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -1,0 +1,47 @@
+/**
+ * 「あとで読む」の localStorage キーと読み書き。
+ *
+ * BookmarkButton にキー文字列と JSON の形が直書きされていたため、
+ * 保存した記事を見返す画面を作るのに実装を読み解く必要があった。
+ */
+export const BOOKMARKS_KEY = 'kt-tech-bookmarks';
+
+/** 保存件数の上限。無制限にすると localStorage の容量を圧迫する */
+export const MAX_BOOKMARKS = 50;
+
+export type Bookmark = {
+  id: string;
+  title: string;
+  savedAt: string;
+};
+
+/** 保存済みブックマークを新しい順で返す。壊れた値が入っていても落とさない */
+export function getBookmarks(): Bookmark[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = JSON.parse(localStorage.getItem(BOOKMARKS_KEY) || '[]');
+    if (!Array.isArray(stored)) return [];
+    return stored.filter(
+      (b): b is Bookmark =>
+        b && typeof b.id === 'string' && typeof b.title === 'string' && typeof b.savedAt === 'string'
+    );
+  } catch {
+    return [];
+  }
+}
+
+function save(bookmarks: Bookmark[]) {
+  localStorage.setItem(BOOKMARKS_KEY, JSON.stringify(bookmarks.slice(0, MAX_BOOKMARKS)));
+}
+
+export function addBookmark(bookmark: Bookmark) {
+  save([bookmark, ...getBookmarks().filter((b) => b.id !== bookmark.id)]);
+}
+
+export function removeBookmark(id: string) {
+  save(getBookmarks().filter((b) => b.id !== id));
+}
+
+export function isBookmarked(id: string): boolean {
+  return getBookmarks().some((b) => b.id === id);
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,91 @@
+import type { Blog } from '../../libs/notion';
+
+/** 記事のどこがキーワードに一致したか */
+export type MatchField = 'title' | 'description' | 'tag' | 'category';
+
+export type SearchHit = {
+  blog: Blog;
+  /** 一致した場所。結果に「なぜ出てきたか」を示すのに使う */
+  matched: MatchField[];
+};
+
+/**
+ * 検索キーワードを語に分割する。
+ *
+ * 全角スペースも区切りとして扱う。日本語入力では半角に切り替えずに
+ * スペースを打つことが多く、区切られないと1語として扱われて0件になる。
+ */
+export function parseQuery(raw: string): string[] {
+  return raw
+    .trim()
+    .split(/[\s　]+/)
+    .filter(Boolean)
+    .map((t) => t.toLowerCase());
+}
+
+/**
+ * 1記事が全ての語を含むか判定し、一致箇所を返す。
+ *
+ * AND 検索なので「語ごとにどこかに一致していること」が条件。
+ * 「react hooks」で、タイトルに react・タグに hooks があれば一致とする。
+ *
+ * 注意: 本文は対象外。`getList()` は本文を取得しない（`pageToBlog(page, false)`）ので、
+ * `blog.body` は常に空文字列になる。以前は body も条件に入っていたが、
+ * 常に false になるだけの分岐だった。
+ */
+export function matchBlog(blog: Blog, terms: string[]): MatchField[] | null {
+  if (terms.length === 0) return null;
+
+  const title = blog.title.toLowerCase();
+  const description = (blog.ogpDescription || '').toLowerCase();
+  const tags = (blog.tags || []).map((t) => t.name.toLowerCase());
+  const category = (blog.category?.name || '').toLowerCase();
+
+  const matched = new Set<MatchField>();
+  for (const term of terms) {
+    let hit = false;
+    if (title.includes(term)) { matched.add('title'); hit = true; }
+    if (description.includes(term)) { matched.add('description'); hit = true; }
+    if (tags.some((t) => t.includes(term))) { matched.add('tag'); hit = true; }
+    if (category.includes(term)) { matched.add('category'); hit = true; }
+    // 1語でもどこにも無ければ AND 条件を満たさない
+    if (!hit) return null;
+  }
+  return Array.from(matched);
+}
+
+/**
+ * 一致箇所の強さ。
+ *
+ * 概要にたまたま単語が出てくるだけの記事が、その技術をタグに持つ記事より
+ * 上に来るのは期待とずれる。タイトル > タグ/カテゴリ > 概要 の順で評価する。
+ */
+const FIELD_WEIGHT: Record<MatchField, number> = {
+  title: 4,
+  tag: 2,
+  category: 2,
+  description: 1,
+};
+
+/** 一致の強い順、同点なら新しい記事を上に */
+export function searchBlogs(blogs: Blog[], raw: string): SearchHit[] {
+  const terms = parseQuery(raw);
+  if (terms.length === 0) return [];
+
+  return blogs
+    .map((blog) => ({ blog, matched: matchBlog(blog, terms) }))
+    .filter((hit): hit is SearchHit => hit.matched !== null)
+    .sort((a, b) => {
+      const score = (hit: SearchHit) => hit.matched.reduce((n, f) => n + FIELD_WEIGHT[f], 0);
+      const diff = score(b) - score(a);
+      if (diff !== 0) return diff;
+      return new Date(b.blog.createdAt).getTime() - new Date(a.blog.createdAt).getTime();
+    });
+}
+
+export const MATCH_LABELS: Record<MatchField, string> = {
+  title: 'タイトル',
+  description: '概要',
+  tag: 'タグ',
+  category: 'カテゴリ',
+};


### PR DESCRIPTION
## まず、実害のあったバグ2つ

### 1. 新しい記事が検索に出てこなかった（#380）

`/searches` に `export const runtime = 'edge'` がなく、ビルド時に一度だけ `getList()` が走った結果が静的に焼き込まれていました。記事を公開しても**次のデプロイまで検索結果に現れません**。

ビルドログでも確認できます。修正前は `/searches` の prerender が実行されて失敗し、修正後はビルドが最後まで通って `ƒ /searches`（動的）になりました。

### 2. 検索エンジン経由の流入が空ページに着地していた

`layout.tsx` の構造化データ（`SearchAction`）だけが `?keyword=` を送っていました。

```
urlTemplate: `${url}/searches?keyword={search_term_string}`
```

一方、サイト内のフォーム・モーダル・404ページ・トップの JSON-LD はすべて `?text=`。検索ページも `searchParams.get('text')` しか見ていないので、`keyword` で来た人には**何も表示されません**。`text` に統一し、念のため検索ページ側は両方受けるようにしました。

## Issue の前提が違っていた件（#379）

「検索ページが全記事の本文をHTMLに埋め込んでいて肥大化している」——これは**起きていません**。`getList()` は `pageToBlog(page, false)` で呼ばれるので、本文は取得されず `body` は常に空文字列です。

ただし同じ理由で、検索条件のこの行が**常に false** でした。

```ts
content.body.toLowerCase().includes(text.toLowerCase()) ||   // '' に対する includes → 常に false
```

本文検索は一度も機能しておらず、実際にはタイトル・タグ・カテゴリだけを見ていました。死んだ分岐を削除し、検索対象を UI に明記しています。本文検索を実現する案は #379 にコメントで整理しました（現アーキテクチャだと一長一短なので、判断を仰ぐため Issue は開いたままにしています）。

## 検索体験

| Issue | 内容 |
| --- | --- |
| #381 | 検索ページに入力欄を置いた。これまで「上部の検索フォームから」と案内していたが、ヘッダーにあるのは検索アイコンでフォームではなかった |
| #383 | スペース区切りの AND 検索。全角スペースも区切りとして扱う（日本語入力では半角に切り替えずスペースを打つことが多く、1語扱いされて0件になっていた） |
| #382 | 結果に一致箇所（タイトル / 概要 / タグ / カテゴリ）を表示 |
| #370 | Cmd+K モーダルに候補表示。↑↓ で選んで Enter で直接開ける |

並び順も直しました。以前は「タイトル一致か否か」だけで、概要にたまたま単語が出てくる記事が、その技術をタグに持つ記事より上に来ていました。タイトル > タグ/カテゴリ > 概要 の重み付けにしています。

モーダルの候補用インデックスは Edge の route handler (`/api/search-index`) が返します。**新しいデータの置き場は作っていません** — 既に `getList()` で取れるものを、本文抜きの軽量な形で返すだけです。最初にモーダルを開いたときだけ取得し、5分キャッシュします。

## その他

- **#363 / #361 / #360**: 一覧と検索結果で丸ごと重複していたカード UI を `PostCard` に統合。固定高 `h-[140px]` をやめ、抜粋を出すようにしました。連載バッジを足したときに一覧側だけ対応して検索側が取り残されていたので、統合しないと同じことが起き続けます。
- **#399**: `/bookmarks` を追加。「あとで読む」で保存はできるのに見返す画面がなく、保存した記事に二度とたどり着けませんでした。localStorage の読み書きが `BookmarkButton` に直書きだったので `src/lib/bookmarks.ts` に切り出しています。
- **#400**: `j` / `k` のショートカットを前後記事ナビの下に明記。hover のない端末（＝キーボードが無いことが多い）では出しません。

## 抜粋についての注意（#360）

抜粋には Notion の `OGP Description` を使っています。本文の自動抜粋ではないので、このプロパティが空の記事ではタイトルだけの表示に戻ります。本文を使えないのは #379 と同じ理由（`getList()` が本文を取得しない）です。

## 確認したこと

- `tsc --noEmit` / `next lint` クリーン、`next build` が最後まで完走（修正前は `/searches` の prerender で失敗していた）
- ルート表で `/searches` が `ƒ`（動的）、`/api/search-index` が `ƒ`、`/bookmarks` が `○`（クライアント完結なので静的で正しい）になっていること
- 検索ロジックをデータを与えて実行し、8ケースを確認:
  - AND 検索（`react hooks` → 該当1件）
  - 全角スペース区切り（`react hooks` が同じ結果になる）
  - 大文字小文字を無視すること
  - 語の順序が違っても同じ結果になること（`edge cloudflare`）
  - 一致の強さ順に並ぶこと（タイトル一致 → タグ一致 → 概要一致）
  - 空文字・空白のみで0件になること
- Chromium で実際に操作して確認:
  - モーダルの候補が絞り込まれ、タイトル一致が上に来ること
  - ↑↓ で選択が動き、Enter で該当記事に遷移すること（`/blogs/d` への遷移を確認）
  - `aria-activedescendant` が選択に追随すること
  - カードがライト/ダーク両方で崩れないこと、375px 幅で横スクロールが出ないこと

Closes #360
Closes #361
Closes #363
Closes #370
Closes #380
Closes #381
Closes #382
Closes #383
Closes #399
Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_