### PR TITLE
security: Notion 由来のテキストをエスケープし、CSP を Report-Only で入れる

### DIFF
--- a/libs/notion.ts
+++ b/libs/notion.ts
@@ -321,12 +321,23 @@ async function blocksToMarkdown(blockId: string, indent = ''): Promise<string> {
 
 // rich_textをマークダウン形式に変換 (インライン装飾対応)
 // bold/italic/codeが混在する場合はHTMLタグで出力して確実に変換
+// レンダリング側の markdown-it は html: true で動くため、本文に生の <  > が
+// 残っているとそのままタグとして解釈される。Notion に `<img onerror=...>` と
+// 書けば実行されてしまう状態だった。記事を書けるのは本人だけなので実害は
+// 限定的だが、意図せずタグが壊れる事故のほうが起きやすい。
+function escapeInlineText(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function richTextToMarkdown(richText: any[]): string {
   if (!richText) return '';
   return richText.map((t: any) => {
-    let text = t.plain_text;
     const annotations = t.annotations || {};
-    if (annotations.code) text = `\`${text}\``;
+    // インラインコードの中身は markdown-it 側でエスケープされる。
+    // ここで先にエスケープすると `&lt;` がそのまま画面に出てしまう。
+    let text = annotations.code
+      ? `\`${t.plain_text}\``
+      : escapeInlineText(t.plain_text);
     if (annotations.bold) text = `<strong>${text}</strong>`;
     if (annotations.italic) text = `<em>${text}</em>`;
     if (annotations.strikethrough) text = `<del>${text}</del>`;
@@ -336,7 +347,12 @@ function richTextToMarkdown(richText: any[]): string {
     if (typeof annotations.color === 'string' && annotations.color.endsWith('_background')) {
       text = `<mark class="mark-${annotations.color.replace('_background', '')}">${text}</mark>`;
     }
-    if (t.href) text = `[${text}](${t.href})`;
+    if (t.href) {
+      // リンク先は <...> で囲む。素の `[text](url)` だと URL に空白や ) が
+      // 含まれるだけでリンクが壊れ、後続の本文まで巻き込む。
+      // javascript: などの危険なスキームは markdown-it の validateLink が既に弾く。
+      text = `[${text}](<${String(t.href).replace(/[<>]/g, encodeURIComponent)}>)`;
+    }
     return text;
   }).join('');
 }

--- a/next.config.js
+++ b/next.config.js
@@ -50,6 +50,40 @@ const nextConfig = {
           { key: 'Cache-Control', value: 'public, s-maxage=3600, stale-while-revalidate=86400, max-age=0' },
         ],
       },
+      {
+        // まずは Report-Only で入れる。
+        // 本文には Notion 由来の生HTMLが通るので多層防御として CSP は有効だが、
+        // GA / AdSense / R2 / 埋め込み先まで許可漏れなく書けているかは
+        // 実際の配信環境でしか確かめられない。いきなり強制すると、
+        // 漏れがあったページで解析や広告や画像が黙って止まる。
+        // ブラウザの Console に違反が出なくなったことを確認してから
+        // Content-Security-Policy に切り替える。
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: [
+              "default-src 'self'",
+              // Next.js のインラインスクリプトと GA / AdSense
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.google.com",
+              // Tailwind とコンポーネントのインラインスタイル
+              "style-src 'self' 'unsafe-inline'",
+              "font-src 'self' data:",
+              // R2 のアイキャッチ / Notion の署名付き画像 / favicon / YouTube のサムネイル
+              "img-src 'self' data: blob: https://pub-9d03846db4364486bb0806774184931a.r2.dev https://prod-files-secure.s3.us-west-2.amazonaws.com https://www.notion.so https://i.ytimg.com https://www.google.com https://*.googlesyndication.com https://*.google-analytics.com",
+              "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
+              // 記事内の埋め込み
+              "frame-src https://www.youtube-nocookie.com https://codesandbox.io https://stackblitz.com https://speakerdeck.com https://www.figma.com https://www.google.com https://*.googlesyndication.com",
+              "object-src 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+              "frame-ancestors 'none'",
+            ].join('; '),
+          },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ],
+      },
     ];
   },
 };

--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -52,6 +52,7 @@ import { KeyboardNav } from '@/components/KeyboardNav/KeyboardNav';
 import { FloatingTocButton } from '@/components/TableOfContents/FloatingTocButton';
 import { BookmarkButton } from '@/components/Bookmark/BookmarkButton';
 import { SeriesNav } from '@/components/Series/SeriesNav';
+import { ArticleAside } from '@/components/ArticleAside/ArticleAside';
 import { findSeriesOf } from '@/lib/series';
 import { isPublic } from '@/lib/blog';
 import { calloutKindFromColor, CALLOUT_META } from '@/lib/callout';
@@ -566,9 +567,11 @@ export default async function StaticDetailPage({
           <FloatingShareButton title={blog.title} url={`${process.env.SITE_URL}/blogs/${blog.id}`} />
           </article>
         </div>
-        {/* 目次は視覚的には右、DOM順では本文のあと */}
+        {/* 目次は視覚的には右、DOM順では本文のあと。
+            サイドバーが出ないページなので、目次の下に回遊導線を足す。 */}
         <div className='lg:col-span-1 lg:order-2 hidden lg:block'>
           <StickyTableOfContents toc={toc} />
+          <ArticleAside blog={blog} latest={navPosts.filter((p) => p.id !== blogId).slice(0, 5)} />
         </div>
       </div>
     </>

--- a/src/components/ArticleAside/ArticleAside.tsx
+++ b/src/components/ArticleAside/ArticleAside.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import type { Blog } from '../../../libs/notion';
+import { CategoryChip, TagChip } from '../Chip/Chip';
+
+/**
+ * 記事詳細の右カラム、目次の下に置く回遊導線。
+ *
+ * サイドバー（WithSidebar）はトップと記事詳細には出ないので、
+ * 記事を読み終えた読者には「関連記事3件 + 前後記事」しか残らず、
+ * タグやカテゴリで横に広げる手段がなかった。
+ * 記事上部のタグはその頃には画面外に出ている。
+ *
+ * 目次はスクロール追従なので、その下に置けば本文の邪魔にならない。
+ */
+export const ArticleAside = ({ blog, latest }: { blog: Blog; latest: Blog[] }) => {
+  const hasTaxonomy = Boolean(blog.category) || Boolean(blog.tags?.length);
+  if (!hasTaxonomy && latest.length === 0) return null;
+
+  return (
+    <div className='mt-6 space-y-6 px-4 text-sm'>
+      {hasTaxonomy && (
+        <section>
+          <h2 className='mb-3 text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400'>
+            この記事のトピック
+          </h2>
+          <div className='flex flex-wrap gap-2'>
+            {blog.category && (
+              <CategoryChip
+                name={blog.category.name}
+                href={`/categories/${encodeURIComponent(blog.category.id)}/page/1`}
+                size='sm'
+              />
+            )}
+            {blog.tags?.map((tag) => (
+              <TagChip key={tag.id} name={tag.name} href={`/tags/${encodeURIComponent(tag.id)}/page/1`} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {latest.length > 0 && (
+        <section>
+          <h2 className='mb-3 text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400'>
+            最新の記事
+          </h2>
+          <ul className='space-y-2.5'>
+            {latest.map((post) => (
+              <li key={post.id}>
+                <Link
+                  href={`/blogs/${post.id}`}
+                  className='block text-slate-600 transition-colors hover:text-blue-600 dark:text-slate-300 dark:hover:text-blue-400'
+                >
+                  <span className='line-clamp-2 leading-snug'>{post.title}</span>
+                  <time
+                    dateTime={post.createdAt}
+                    className='mt-0.5 block text-xs text-slate-400 dark:text-slate-500'
+                  >
+                    {post.createdAt.slice(0, 10).replace(/-/g, '/')}
+                  </time>
+                </Link>
+              </li>
+            ))}
+          </ul>
+          <Link
+            href='/blogs/page/1'
+            className='mt-3 inline-block text-xs text-slate-500 underline hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+          >
+            記事一覧を見る
+          </Link>
+        </section>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
#485 の残っていた2点（`richTextToMarkdown` のエスケープ、CSP）と、#409 に対応します。

## 本文のエスケープ（#485）

レンダリング側の markdown-it は `html: true` で動くため、本文に生の `<` `>` が残っているとそのままタグとして解釈されます。Notion に ``'&lt;img src=x onerror=...&gt;'`` と書けば実行されてしまう状態でした。

記事を書けるのは本人だけなので実害は限定的ですが、**意図せずタグが壊れる事故のほうが起きやすい**（`a < b` と書いただけで以降がタグ扱いになる）ので直します。

**インラインコードの中身だけは触りません。** markdown-it 側でエスケープされるので、先にエスケープすると `&lt;` がそのまま画面に出てしまいます。

リンク先は `<...>` で囲むようにしました。素の `[text](url)` だと URL に空白や `)` が含まれるだけでリンクが壊れ、後続の本文まで巻き込みます。

**`javascript:` の検証は追加していません。** markdown-it の `validateLink` が `BAD_PROTO_RE = /^(vbscript|javascript|file|data):/` で既に弾いており、実際に通してアンカーにならないことを確認したためです（下記）。重複した検証を足すより、既にある防御に任せるほうが読みやすいと判断しました。

## CSP（#485）

**まずは `Content-Security-Policy-Report-Only` で入れます。**

多層防御として価値はありますが、GA / AdSense / R2 / 埋め込み先まで許可漏れなく書けているかは実際の配信環境でしか確かめられません。いきなり強制すると、漏れがあったページで解析や広告や画像が**黙って止まります**。ブラウザの Console に違反が出なくなったのを確認してから `Content-Security-Policy` に切り替えてください（キー名を変えるだけです）。

`X-Content-Type-Options: nosniff` と `Referrer-Policy: strict-origin-when-cross-origin` も併せて追加しました。

## 記事詳細の回遊導線（#409）

サイドバー（`WithSidebar`）はトップと記事詳細に出ないため、記事を読み終えた読者には「関連記事3件 + 前後記事」しか残らず、タグやカテゴリで横に広げる手段がありませんでした。記事上部のタグはその頃には画面外に出ています。

目次はスクロール追従なので、その下に「この記事のトピック（カテゴリ + タグ）」と「最新の記事」を置きました。トップページ側は前回のPRでフッターを拡張したので、そちらで導線が確保されています。

## 確認したこと

- `tsc --noEmit` / `next lint` クリーン、`next build` 完走、`next.config.js` が読み込めること
- `richTextToMarkdown` を実装から直接読み込んで10ケース実行:
  - ``'&lt;img src=x onerror=alert(1)&gt;'`` → `&lt;img src=x onerror=alert(1)&gt;`
  - `a < b && c > d` → `a &lt; b &amp;&amp; c &gt; d`
  - インラインコード `const x = <T,>() => {}` は**エスケープされず**そのまま
  - `)` や空白を含む URL が `[リンク](<...>)` になること
- markdown-it を通した最終HTMLも確認:
  - `<code>const x = &lt;T,&gt;() =&gt; {}</code>（`<T,>` として正しく表示される）
  - `javascript:alert(1)` は**アンカーにならず**素のテキストとして出る
  - `)` を含む URL は `<a href="https://example.com/a(b)c">` になる

Closes #409
Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_