### PR TITLE
feat: 記事の要約セクションと更新履歴を追加する

### DIFF
--- a/libs/notion.ts
+++ b/libs/notion.ts
@@ -28,11 +28,23 @@ export type Series = {
   order: number;
 };
 
+/** 更新履歴の1行。`YYYY-MM-DD 内容` の形で書かれたものを分解したもの */
+export type ChangelogEntry = {
+  date: string;
+  description: string;
+};
+
 export type Blog = {
   id: string; // Slug (microCMS IDまたはNotion page ID)
   title: string;
   body: string;
   ogpDescription?: string;
+  /** 「この記事でわかること」。Notion の Summary プロパティを改行で分割したもの */
+  summary?: string[];
+  /** 前提知識・動作環境。Notion の Prerequisites プロパティ */
+  prerequisites?: string;
+  /** 更新履歴。Notion の Changelog プロパティ */
+  changelog?: ChangelogEntry[];
   eyecatch?: { url: string; height?: number; width?: number };
   category?: Category;
   tags?: Tag[];
@@ -376,6 +388,23 @@ function richTextToMarkdown(richText: any[]): string {
   }).join('');
 }
 
+/**
+ * 更新履歴のテキストを解釈する。
+ *
+ * `2026-07-15  Next.js 15.1 での挙動変更を追記` のように
+ * 1行1件で書かれたものを想定する。日付で始まらない行は無視する
+ * （見出しやメモを混ぜても表示が壊れないようにするため）。
+ */
+function parseChangelog(text: string): ChangelogEntry[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim().match(/^(\d{4}[-/]\d{1,2}[-/]\d{1,2})\s+(.+)$/))
+    .filter((m): m is RegExpMatchArray => m !== null)
+    .map((m) => ({ date: m[1].replace(/\//g, '-'), description: m[2].trim() }))
+    // 新しい順に並べる。書き手が古い順に書いていても表示は揃う
+    .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+}
+
 // NotionのページからBlog型に変換
 async function pageToBlog(page: any, fetchBody: boolean = false): Promise<Blog> {
   const props = page.properties;
@@ -388,6 +417,16 @@ async function pageToBlog(page: any, fetchBody: boolean = false): Promise<Blog> 
   const ogpDescription = richTextToPlain(props['OGP Description']?.rich_text || []) || '';
   const createdDate = props.Created?.date?.start || page.created_time;
   const id = slug || page.id.replace(/-/g, '');
+
+  // 「この記事でわかること」と更新履歴。連載と同じく、プロパティが未作成の
+  // データベースでも落ちないよう全て省略可能に扱う。
+  // 書き手が埋めていない記事はこれまで通りの表示になる。
+  const summary = richTextToPlain(props.Summary?.rich_text || [])
+    .split('\n')
+    .map((line: string) => line.replace(/^[-・*]\s*/, '').trim())
+    .filter(Boolean);
+  const prerequisites = richTextToPlain(props.Prerequisites?.rich_text || []).trim();
+  const changelog = parseChangelog(richTextToPlain(props.Changelog?.rich_text || []));
 
   // 連載。プロパティが未作成のデータベースでも落ちないよう、全て省略可能に扱う。
   const seriesName = (props.Series?.select?.name || '').trim();
@@ -405,6 +444,9 @@ async function pageToBlog(page: any, fetchBody: boolean = false): Promise<Blog> 
     title,
     body,
     ogpDescription: ogpDescription || undefined,
+    summary: summary.length > 0 ? summary : undefined,
+    prerequisites: prerequisites || undefined,
+    changelog: changelog.length > 0 ? changelog : undefined,
     eyecatch: eyecatchUrl ? { url: eyecatchUrl, width: 1200, height: 630 } : undefined,
     category: categoryName ? pageToCategory(categoryName) : undefined,
     tags,

--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -58,6 +58,8 @@ import { FloatingTocButton } from '@/components/TableOfContents/FloatingTocButto
 import { BookmarkButton } from '@/components/Bookmark/BookmarkButton';
 import { SeriesNav } from '@/components/Series/SeriesNav';
 import { ArticleAside } from '@/components/ArticleAside/ArticleAside';
+import { ArticleSummary } from '@/components/ArticleSummary/ArticleSummary';
+import { ArticleChangelog } from '@/components/ArticleSummary/ArticleChangelog';
 import { findSeriesOf } from '@/lib/series';
 import { isPublic } from '@/lib/blog';
 import { calloutKindFromColor, CALLOUT_META } from '@/lib/callout';
@@ -90,7 +92,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const rawHtml = md.render(cleanBody);
   const text = stripHtml(rawHtml);
 
-  const description = blog.ogpDescription || text.slice(0, 120).replace(/\n/g, ' ').trim();
+  // 説明文の優先順位は OGP Description → 要約 → 本文の先頭。
+  // 本文の切り出しは導入の雑談から始まることが多く、検索結果で役に立たない。
+  const description =
+    blog.ogpDescription ||
+    (blog.summary?.length ? blog.summary.join('、').slice(0, 120) : '') ||
+    text.slice(0, 120).replace(/\n/g, ' ').trim();
   const ogImage = blog.eyecatch?.url;
   const pageUrl = `${process.env.SITE_URL}/blogs/${blogId}`;
 
@@ -311,6 +318,7 @@ export default async function StaticDetailPage({
     // リンク記法 `[文字](url)` や表の `|`、リストの `-` が説明文に混ざっていた。
     // レンダリング後のHTMLから起こした平文を使えば、記法は残らない。
     description: (blog.ogpDescription || plainText).replace(/\s+/g, ' ').slice(0, 160).trim(),
+    ...(blog.summary?.length ? { abstract: blog.summary.join(' / ') } : {}),
     image: blog.eyecatch?.url || `${process.env.SITE_URL}/opengraph-image`,
     datePublished: new Date(blog.publishedAt).toISOString(),
     dateModified: new Date(blog.updatedAt).toISOString(),
@@ -451,6 +459,11 @@ export default async function StaticDetailPage({
                 />
               </div>
             )}
+            {/* 検索から来た読者は数秒で「自分の課題が解決するか」を判断する。
+                目次の前に結論と前提を置く。 */}
+            <div className='mx-4'>
+              <ArticleSummary blog={blog} />
+            </div>
             {/* モバイルの目次は右下のFABに一本化した。
                 以前は本文上のアコーディオンとFABが同時に存在し、
                 同じものが2つ出ていたうえ、アコーディオンは本文の先頭を占有していた。 */}
@@ -475,6 +488,7 @@ export default async function StaticDetailPage({
               <ImageLightbox />
               <ReadingTracker articleId={blogId} />
             </div>
+            {blog.changelog && <ArticleChangelog entries={blog.changelog} />}
             {/* 記事末: タグ → シェア/著者/フィードバック → 前後記事 → 関連記事。
                 以前はシェアが記事上部と末尾の2箇所にあり、著者カードもリンク先がなかった。 */}
             {blog.tags && blog.tags.length > 0 && (

--- a/src/components/ArticleSummary/ArticleChangelog.tsx
+++ b/src/components/ArticleSummary/ArticleChangelog.tsx
@@ -1,0 +1,38 @@
+import { History } from 'lucide-react';
+import type { ChangelogEntry } from '../../../libs/notion';
+
+/**
+ * 記事末尾の更新履歴。
+ *
+ * 日付だけでは「何が更新されたか」が分からない。誤字修正なのか、
+ * Next.js 15 対応で内容が大きく変わったのかで、再読すべきかの判断が変わる。
+ *
+ * しかも `updatedAt` は Notion の last_edited_time なので、
+ * タグを1つ足しただけでも更新日が動く。書き手が明示した履歴があれば、
+ * 実質的な変更だけを読者に伝えられる。
+ */
+export const ArticleChangelog = ({ entries }: { entries: ChangelogEntry[] }) => {
+  if (entries.length === 0) return null;
+
+  return (
+    <section className='mt-12 mx-4'>
+      <h2 className='mb-3 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400'>
+        <History className='h-3.5 w-3.5' aria-hidden='true' />
+        更新履歴
+      </h2>
+      <ol className='space-y-2 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-800/50'>
+        {entries.map((entry) => (
+          <li key={`${entry.date}-${entry.description}`} className='flex flex-wrap gap-x-3 gap-y-0.5'>
+            <time
+              dateTime={entry.date}
+              className='shrink-0 tabular-nums text-slate-500 dark:text-slate-400'
+            >
+              {entry.date.replace(/-/g, '/')}
+            </time>
+            <span className='min-w-0 text-slate-700 dark:text-slate-200'>{entry.description}</span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+};

--- a/src/components/ArticleSummary/ArticleSummary.tsx
+++ b/src/components/ArticleSummary/ArticleSummary.tsx
@@ -1,0 +1,53 @@
+import { Pin, Info } from 'lucide-react';
+import type { Blog } from '../../../libs/notion';
+
+/**
+ * 記事冒頭の「この記事でわかること」。
+ *
+ * 検索から来た読者は「自分の課題が解決するか」を数秒で判断する。
+ * 目次は見出しの羅列であって、結論も対象読者も分からない。
+ * 特に「前提知識」「動作環境」が冒頭にないと、読み進めてから
+ * 「バージョンが違って動かない」と気づくことになる。
+ *
+ * Notion の Summary / Prerequisites プロパティが空の記事では何も出さない。
+ */
+export const ArticleSummary = ({ blog }: { blog: Blog }) => {
+  if (!blog.summary?.length && !blog.prerequisites) return null;
+
+  return (
+    <section
+      aria-label='この記事の要約'
+      className='my-6 rounded-xl border border-blue-200 bg-blue-50/60 p-5 dark:border-blue-900 dark:bg-blue-950/30'
+    >
+      {blog.summary && blog.summary.length > 0 && (
+        <>
+          <h2 className='mb-3 flex items-center gap-2 text-sm font-bold text-slate-800 dark:text-slate-100'>
+            <Pin className='h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400' aria-hidden='true' />
+            この記事でわかること
+          </h2>
+          <ul className='space-y-1.5 text-sm text-slate-700 dark:text-slate-200'>
+            {blog.summary.map((line) => (
+              <li key={line} className='flex gap-2'>
+                <span aria-hidden='true' className='select-none text-blue-500 dark:text-blue-400'>
+                  •
+                </span>
+                <span className='min-w-0'>{line}</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {blog.prerequisites && (
+        <p
+          className={`flex gap-2 text-xs leading-relaxed text-slate-600 dark:text-slate-300 ${
+            blog.summary?.length ? 'mt-4 border-t border-blue-200 pt-3 dark:border-blue-900' : ''
+          }`}
+        >
+          <Info className='mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-400 dark:text-slate-500' aria-hidden='true' />
+          <span className='min-w-0'>{blog.prerequisites}</span>
+        </p>
+      )}
+    </section>
+  );
+};


### PR DESCRIPTION
どちらも **Notion のプロパティを任意で埋める形**にしました。連載機能（#435）と同じく、プロパティが未作成のデータベースでも、書き手が埋めていない記事でも、これまで通りの表示になります。

| プロパティ | 型 | 用途 |
| --- | --- | --- |
| `Summary` | Text（複数行） | 「この記事でわかること」。改行で1項目 |
| `Prerequisites` | Text | 対象読者・動作環境 |
| `Changelog` | Text（複数行） | `YYYY-MM-DD 内容` を1行1件 |

## この記事でわかること（#457）

検索から来た読者は「自分の課題が解決するか」を数秒で判断します。目次は**見出しの羅列**であって、結論も対象読者も分かりません。特に「前提知識」「動作環境」が冒頭にないと、読み進めてから「バージョンが違って動かない」と気づくことになります。

要約は `description` メタタグと JSON-LD の `abstract` にも使います。優先順位は `OGP Description` → 要約 → 本文の先頭。本文の切り出しは導入の雑談から始まることが多く、検索結果では役に立たないためです。

## 更新履歴（#458）

日付だけでは何が更新されたか分かりません。誤字修正なのか、Next.js 15 対応で内容が大きく変わったのかで、再読すべきかの判断が変わります。しかも `updatedAt` は Notion の `last_edited_time` なので、**タグを1つ足しただけでも日付が動きます**。

書き手が明示した履歴があれば、実質的な変更だけを伝えられます。日付で始まらない行は無視するので、Notion 側で見出しやメモを混ぜても表示は壊れません。

なお Issue の案C（`updatedAt` を `<time>` 要素にして「最終更新」と明記）は**既に対応済み**でした。案B（本文のハッシュで実質的な更新を検出）は、ハッシュの保存先が必要になるので採用していません。

## 確認したこと

- `tsc --noEmit` / `next lint` クリーン、`next build` 完走
- `parseChangelog` を実装から直接読み込んで5ケース確認:
  - 順不同で書かれた3件が**新しい順に並ぶ**こと
  - `2026/07/15` のスラッシュ区切りも受け付けること
  - 「更新履歴」という見出し行や「メモ:」の行が無視されること
  - 空文字・日付なしの入力で `[]` が返ること
- Chromium でライト/ダーク両方をレンダリングし確認:
  - 要約 + 前提の両方がある場合と、前提のみの場合で罫線の出し分けが正しいこと
  - 更新履歴の日付が等幅（`tabular-nums`）で桁が揃うこと

Closes #457
Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_