### PR TITLE
feat: 検索の対象に要約と連載名を加える

### DIFF
--- a/src/app/api/search-index/route.ts
+++ b/src/app/api/search-index/route.ts
@@ -18,7 +18,8 @@ export async function GET() {
     const index = contents.filter(isPublic).map((blog) => ({
       id: blog.id,
       title: blog.title,
-      description: blog.ogpDescription ?? '',
+      // 「この記事でわかること」も候補の絞り込みに使う
+      description: [blog.ogpDescription, ...(blog.summary ?? [])].filter(Boolean).join(' '),
       tags: blog.tags?.map((t) => t.name) ?? [],
       category: blog.category?.name ?? '',
       series: blog.series?.name ?? '',

--- a/src/app/searches/client_index.tsx
+++ b/src/app/searches/client_index.tsx
@@ -74,7 +74,7 @@ export const ClientIndex = ({ contents }: BlogProps) => {
         </form>
         <p className='mt-2 text-xs text-slate-500 dark:text-slate-400'>
           スペース区切りで複数のキーワードを指定すると、すべてを含む記事を探します。
-          タイトル・概要・タグ・カテゴリが対象です。
+          タイトル・概要・タグ・カテゴリ・連載名が対象です。
         </p>
 
         {text && (

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,7 +1,7 @@
 import type { Blog } from '../../libs/notion';
 
 /** 記事のどこがキーワードに一致したか */
-export type MatchField = 'title' | 'description' | 'tag' | 'category';
+export type MatchField = 'title' | 'description' | 'tag' | 'category' | 'series';
 
 export type SearchHit = {
   blog: Blog;
@@ -32,12 +32,21 @@ export function parseQuery(raw: string): string[] {
  * 注意: 本文は対象外。`getList()` は本文を取得しない（`pageToBlog(page, false)`）ので、
  * `blog.body` は常に空文字列になる。以前は body も条件に入っていたが、
  * 常に false になるだけの分岐だった。
+ * 代わりに、書き手が明示した要約（Summary）を概要に含めている。
+ * 本文そのものより短いが、記事の要点は拾える。
  */
 export function matchBlog(blog: Blog, terms: string[]): MatchField[] | null {
   if (terms.length === 0) return null;
 
   const title = blog.title.toLowerCase();
-  const description = (blog.ogpDescription || '').toLowerCase();
+  // 概要には OGP Description と要約の両方を含める。
+  // 要約は書き手が「この記事でわかること」として書いた文なので、
+  // 本文が引けない以上、いちばん情報量の多い手がかりになる。
+  const description = [blog.ogpDescription, ...(blog.summary ?? [])]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  const series = (blog.series?.name || '').toLowerCase();
   const tags = (blog.tags || []).map((t) => t.name.toLowerCase());
   const category = (blog.category?.name || '').toLowerCase();
 
@@ -48,6 +57,7 @@ export function matchBlog(blog: Blog, terms: string[]): MatchField[] | null {
     if (description.includes(term)) { matched.add('description'); hit = true; }
     if (tags.some((t) => t.includes(term))) { matched.add('tag'); hit = true; }
     if (category.includes(term)) { matched.add('category'); hit = true; }
+    if (series.includes(term)) { matched.add('series'); hit = true; }
     // 1語でもどこにも無ければ AND 条件を満たさない
     if (!hit) return null;
   }
@@ -62,6 +72,8 @@ export function matchBlog(blog: Blog, terms: string[]): MatchField[] | null {
  */
 const FIELD_WEIGHT: Record<MatchField, number> = {
   title: 4,
+  // 連載名での一致は「その連載を探している」意図が強い
+  series: 3,
   tag: 2,
   category: 2,
   description: 1,
@@ -88,4 +100,5 @@ export const MATCH_LABELS: Record<MatchField, string> = {
   description: '概要',
   tag: 'タグ',
   category: 'カテゴリ',
+  series: '連載名',
 };


### PR DESCRIPTION
#506 で `Summary`（この記事でわかること）プロパティを追加したのに、**検索側に繋いでいませんでした**。私の実装漏れです。

書き手が記事の要点として書いた文なので、本文が引けない現状ではいちばん情報量の多い手がかりになります。連載名も検索対象に加えました。

## 変更

- `matchBlog` の「概要」に `OGP Description` + `Summary` を含める
- 連載名を新しい一致箇所 `series` として追加（重み3。タイトル4 > **連載名3** > タグ/カテゴリ2 > 概要1）
- 検索モーダルの候補用インデックス（`/api/search-index`）にも要約を含める
- 検索ページの説明文を実態に合わせる

連載名の重みを3にしたのは、「移行記」のような語で探す読者は**その連載を探している**意図が強いためです。

## 本文検索について

**本文そのものが検索できない状況は変わっていません。** `getList()` は本文を取得しないためで、方式の選択肢（ビルド時インデックス / Notion にキーワードを持たせる / 検索時に全文取得）は #379 にコメントで整理してあります。今回はその判断を待たずにできる範囲の改善です。

## 確認したこと

- `tsc --noEmit` / `next lint` クリーン、`next build` 完走
- 検索ロジックを実装から直接読み込んで5ケース確認:
  - `isr` — **要約にしか無い語**で記事が引けること（一致箇所が `description` になる）
  - `cdn cache` — 要約に対する AND 検索が効くこと
  - `移行記` — **連載名**で引けること（一致箇所が `series` になる）
  - `useState` — `OGP Description` での一致が従来通り効くこと
  - 該当なしのとき空になること

Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_