### PR TITLE
fix: 目次が長いときの見せ方を変え、内側のスクロールバーを細くする

### DIFF
--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -595,7 +595,7 @@ export default async function StaticDetailPage({
               スクロールも1本にまとめる（入れ子のスクロール領域は操作しづらい）。 */}
           <div
             data-toc-rail
-            className='sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto overscroll-contain rounded-lg bg-white/50 p-4 backdrop-blur-sm dark:bg-slate-900/50'
+            className='scrollbar-slim sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto overscroll-contain rounded-lg bg-white/50 p-4 backdrop-blur-sm dark:bg-slate-900/50'
           >
             <StickyTableOfContents toc={toc} />
             <ArticleAside blog={blog} latest={navPosts.filter((p) => p.id !== blogId).slice(0, 5)} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -149,6 +149,49 @@ body {
 
    トークンの値は slate（サイト全体で使っている色）に合わせてある。 */
 
+/* 内側でスクロールする箇所の細いスクロールバー。
+   既定のスクロールバーは幅15px前後と太く、目次のような細い縦のリストの
+   横に置くと本文より主張してしまう。触っていないときは限りなく薄くし、
+   ホバー・フォーカス時だけ掴める濃さにする。
+   （完全に消すと「まだ続きがある」ことが分からなくなるので残す） */
+.scrollbar-slim {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(226 232 240) transparent;
+}
+.dark .scrollbar-slim {
+  scrollbar-color: rgb(30 41 59) transparent;
+}
+.scrollbar-slim:hover,
+.scrollbar-slim:focus-within {
+  scrollbar-color: rgb(148 163 184) transparent;
+}
+.dark .scrollbar-slim:hover,
+.dark .scrollbar-slim:focus-within {
+  scrollbar-color: rgb(71 85 105) transparent;
+}
+.scrollbar-slim::-webkit-scrollbar {
+  width: 6px;
+}
+.scrollbar-slim::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-slim::-webkit-scrollbar-thumb {
+  background: rgb(226 232 240);
+  border-radius: 3px;
+  transition: background 0.2s;
+}
+.dark .scrollbar-slim::-webkit-scrollbar-thumb {
+  background: rgb(30 41 59);
+}
+.scrollbar-slim:hover::-webkit-scrollbar-thumb,
+.scrollbar-slim:focus-within::-webkit-scrollbar-thumb {
+  background: rgb(148 163 184);
+}
+.dark .scrollbar-slim:hover::-webkit-scrollbar-thumb,
+.dark .scrollbar-slim:focus-within::-webkit-scrollbar-thumb {
+  background: rgb(71 85 105);
+}
+
 /* 0.3px はサブピクセルで端末により消える/濃く出るうえ、
    枠色に本文色をそのまま使っていたため記事の中で必要以上に主張していた。 */
 .link-card {

--- a/src/components/TableOfContents/FloatingTocButton.tsx
+++ b/src/components/TableOfContents/FloatingTocButton.tsx
@@ -25,7 +25,7 @@ export const FloatingTocButton = ({ toc }: { toc: TocItem[] }) => {
           <div className={`fixed inset-0 ${FAB_OVERLAY_Z} bg-black/20`} onClick={() => setIsOpen(false)} />
           <nav
             aria-label='目次'
-            className={`fixed bottom-[11rem] left-4 right-4 ${FAB_PANEL_Z} max-h-[60vh] overflow-y-auto rounded-xl border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-900`}
+            className={`scrollbar-slim fixed bottom-[11rem] left-4 right-4 ${FAB_PANEL_Z} max-h-[60vh] overflow-y-auto overscroll-contain rounded-xl border border-slate-200 bg-white p-4 shadow-xl dark:border-slate-700 dark:bg-slate-900`}
           >
             <h3 className='text-sm font-bold text-slate-900 dark:text-slate-100 mb-3'>目次</h3>
             <ul className='space-y-2'>

--- a/src/components/TableOfContents/StickyTableOfContents.tsx
+++ b/src/components/TableOfContents/StickyTableOfContents.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { useState, useEffect, useRef } from 'react';
-import { tocDepth, type TocItem } from '@/lib/toc';
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { tocDepth, groupToc, shouldCollapse, type TocItem } from '@/lib/toc';
 
 /** 階層ごとの字下げ。左のレールからの距離を段階的に広げる */
 const INDENT = ['pl-4', 'pl-8', 'pl-12'] as const;
@@ -81,6 +82,13 @@ export const StickyTableOfContents = ({ toc }: { toc: TocItem[] }) => {
   // ヘッダー分のオフセットは globals.css の scroll-padding-top が担当する。
   const handleClick = (id: string) => setActiveId(id);
 
+  const groups = useMemo(() => groupToc(toc), [toc]);
+  const collapse = useMemo(() => shouldCollapse(toc), [toc]);
+
+  // 読んでいる章とは別に、ユーザーが自分で開いた章。
+  // 「この先どんな話が続くのか」を、そこまでスクロールせずに覗けるようにする。
+  const [peekedId, setPeekedId] = useState<string | null>(null);
+
   if (toc.length === 0) return null;
 
   return (
@@ -91,36 +99,109 @@ export const StickyTableOfContents = ({ toc }: { toc: TocItem[] }) => {
 
       {/* レールは <ul> 側に1本だけ通す。
           以前は項目ごとに border-l を持たせたうえで階層別に ml をずらしていたため、
-          縦線が段違いに途切れて並び、左端がガタついていた。 */}
-      {/* 高さの制限とスクロールは親のレール（[data-toc-rail]）が持つ。
-          ここで overflow を持つと、レールとの二重スクロールになる。 */}
+          縦線が段違いに途切れて並び、左端がガタついていた。
+          高さの制限とスクロールは親のレール（[data-toc-rail]）が持つ。 */}
       <ul ref={listRef} className='border-l border-slate-200 dark:border-slate-700'>
-        {toc.map((item) => {
-          const isActive = activeId === item.id;
+        {groups.map((group, gi) => {
+          // 読んでいる章だけ下位見出しを開く。
+          // 見出しの多い記事で全部並べると目次が本文より長くなり、
+          // 内側にスクロールバーが出て全体像が見えなくなる。
+          const key = group.parent?.id ?? `group-${gi}`;
+          const isCurrent =
+            group.parent?.id === activeId || group.children.some((child) => child.id === activeId);
+          const isOpen = !collapse || isCurrent || peekedId === key;
+          const panelId = `toc-group-${gi}`;
           return (
-            <li key={item.id} data-toc-id={item.id}>
-              <a
-                href={`#${item.id}`}
-                onClick={() => handleClick(item.id)}
-                title={item.text}
-                aria-current={isActive ? 'location' : undefined}
-                // 現在地は -ml-px の太い線で共通レールを上書きする。
-                // レール自体は動かないので段差にならない。
-                className={`-ml-px block border-l-2 py-1.5 pr-2 leading-snug transition-colors ${
-                  INDENT[tocDepth(item.tag)]
-                } ${tocDepth(item.tag) === 0 ? 'text-[13px]' : 'text-xs'} ${
-                  isActive
-                    ? 'border-blue-500 bg-blue-50 font-medium text-blue-600 dark:bg-blue-950/40 dark:text-blue-400'
-                    : 'border-transparent text-slate-500 hover:bg-slate-50 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800/60 dark:hover:text-slate-200'
-                }`}
-              >
-                {/* 2行までに収める。3行以上の見出しが並ぶと目次が本文より長くなる */}
-                <span className='line-clamp-2'>{item.text}</span>
-              </a>
+            <li key={key}>
+              {group.parent && (
+                <TocLink
+                  item={group.parent}
+                  activeId={activeId}
+                  onSelect={handleClick}
+                  toggle={
+                    collapse && group.children.length > 0
+                      ? {
+                          isOpen,
+                          panelId,
+                          // 読んでいる章は閉じても次のスクロールで開き直るだけなので、畳ませない
+                          onToggle: () => setPeekedId(isOpen && !isCurrent ? null : key),
+                        }
+                      : undefined
+                  }
+                />
+              )}
+              {group.children.length > 0 && (
+                <ul id={panelId} hidden={!isOpen}>
+                  {group.children.map((child) => (
+                    <li key={child.id}>
+                      <TocLink item={child} activeId={activeId} onSelect={handleClick} />
+                    </li>
+                  ))}
+                </ul>
+              )}
             </li>
           );
         })}
       </ul>
     </nav>
+  );
+};
+
+/** 目次の1項目。章見出しと小見出しで見た目を変える */
+const TocLink = ({
+  item,
+  activeId,
+  onSelect,
+  toggle,
+}: {
+  item: TocItem;
+  activeId: string;
+  onSelect: (id: string) => void;
+  /** 下位見出しの開閉。折りたたむ必要のない目次では渡さない */
+  toggle?: { isOpen: boolean; panelId: string; onToggle: () => void };
+}) => {
+  const isActive = activeId === item.id;
+  const depth = tocDepth(item.tag);
+  return (
+    // 現在地は -ml-px の太い線で共通レールを上書きする。
+    // レール自体は動かないので段差にならない。
+    // 開閉ボタンはリンクの隣に置く。リンクの中に入れると
+    // 「小見出しを覗きたいだけ」でも本文が飛んでしまう。
+    <div
+      className={`-ml-px flex items-start border-l-2 transition-colors ${
+        isActive
+          ? 'border-blue-500 bg-blue-50 text-blue-600 dark:bg-blue-950/40 dark:text-blue-400'
+          : 'border-transparent text-slate-500 hover:bg-slate-50 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800/60 dark:hover:text-slate-200'
+      }`}
+    >
+      <a
+        href={`#${item.id}`}
+        onClick={() => onSelect(item.id)}
+        title={item.text}
+        data-toc-id={item.id}
+        aria-current={isActive ? 'location' : undefined}
+        className={`min-w-0 flex-1 py-1.5 pr-1 leading-snug ${INDENT[depth]} ${
+          depth === 0 ? 'text-[13px]' : 'text-xs'
+        } ${isActive ? 'font-medium' : ''}`}
+      >
+        {/* 2行までに収める。3行以上の見出しが並ぶと目次が本文より長くなる */}
+        <span className='line-clamp-2'>{item.text}</span>
+      </a>
+      {toggle && (
+        <button
+          type='button'
+          onClick={toggle.onToggle}
+          aria-expanded={toggle.isOpen}
+          aria-controls={toggle.panelId}
+          aria-label={`${item.text} の小見出しを${toggle.isOpen ? '閉じる' : '開く'}`}
+          className='shrink-0 self-stretch px-1.5 text-slate-400 hover:text-slate-700 dark:text-slate-500 dark:hover:text-slate-200'
+        >
+          <ChevronRight
+            className={`h-3.5 w-3.5 transition-transform ${toggle.isOpen ? 'rotate-90' : ''}`}
+            aria-hidden='true'
+          />
+        </button>
+      )}
+    </div>
   );
 };

--- a/src/lib/toc.ts
+++ b/src/lib/toc.ts
@@ -12,3 +12,41 @@ export function tocDepth(tag: string): number {
   if (!Number.isFinite(level)) return 0;
   return Math.max(0, Math.min(2, level - 2));
 }
+
+/** 最上位の見出しと、その配下にぶら下がる下位見出し */
+export type TocGroup = {
+  /** 章の見出し。文書が下位見出しから始まる場合だけ null */
+  parent: TocItem | null;
+  children: TocItem[];
+};
+
+/**
+ * 目次を「最上位の見出し + その配下」の塊に分ける。
+ *
+ * 見出しが多い記事では、下位見出しまで常に並べると目次が本文より長くなり、
+ * 内側にスクロールバーが出て全体像が見えなくなる。
+ * 読んでいる章の下位見出しだけを開く、という見せ方をするための下ごしらえ。
+ */
+export function groupToc(toc: TocItem[]): TocGroup[] {
+  const groups: TocGroup[] = [];
+  for (const item of toc) {
+    if (tocDepth(item.tag) === 0 || groups.length === 0) {
+      groups.push({ parent: tocDepth(item.tag) === 0 ? item : null, children: [] });
+      if (tocDepth(item.tag) === 0) continue;
+    }
+    groups[groups.length - 1].children.push(item);
+  }
+  return groups;
+}
+
+/**
+ * 下位見出しを折りたたむかどうか。
+ *
+ * 短い目次まで畳むと、開閉のたびに項目が動くだけで何も得しない。
+ * 全部並べても収まる長さなら、そのまま出したほうが読みやすい。
+ */
+export const TOC_COLLAPSE_THRESHOLD = 12;
+
+export function shouldCollapse(toc: TocItem[]): boolean {
+  return toc.length > TOC_COLLAPSE_THRESHOLD && toc.some((item) => tocDepth(item.tag) > 0);
+}


### PR DESCRIPTION
## 何が問題だったか

見出しの多い記事だと目次が20項目を超え、右カラムに収まりきらずに**内側のスクロールバー**が出ていた。

- 目次の全体像が一目で掴めない（読んでいる場所の前後しか見えない）
- 既定のスクロールバーは幅15px前後あり、細い縦のリストの横に置くと本文より主張する

## どう直したか

### 1. 読んでいる章の小見出しだけを開く

目次を「章（h2）+ その配下の小見出し」の塊に分け、いま読んでいる章だけ小見出しを展開する。

実測（h2 5本 × h3 3本 = 20項目、1280×900）:

| | 変更前 | 変更後 |
|---|---|---|
| 常時表示される行数 | 20 | 8 |
| 内側スクロール | あり | **なし**（scrollHeight 592 == clientHeight 592） |

スクロールに応じて開く章が入れ替わることも確認した（`3.` の途中 → 「3. Notion を CMS として…」が展開、末尾 → 「5. まとめと…」が展開）。

畳むのは**項目が12個より多く、かつ小見出しがある目次だけ**。短い目次まで畳むと項目が動くだけで何も得しないので、今まで通り全部並べる。

### 2. 開閉できる章にシェブロンを付けた

自動で開け閉めするだけだと、スクロール中に項目が増減する理由が読者に分からない。開閉できる章にシェブロンを置いて、状態が見えるようにした。

押すと**本文を動かさずに**その章の小見出しを覗ける（`window.scrollY` が 0 のまま変化しないことを確認）。リンクの中にボタンを入れず横に並べているのはこのため。いま読んでいる章は、畳んでも次のスクロールで開き直るだけなので畳ませない。

### 3. `.scrollbar-slim`

背の低いウィンドウなど、畳んでもなお溢れる場合のために細いスクロールバーを用意した。触っていないときは限りなく薄く（slate-200 / dark: slate-800）、ホバー・フォーカス時だけ掴める濃さ（slate-400 / dark: slate-600）にする。完全に消すと「まだ続きがある」ことが分からなくなるので残している。

デスクトップの目次レールとモバイルの目次パネルの両方に当てた。モバイルのパネルには併せて `overscroll-contain` も追加（パネルの端まで来たとき背後の本文が動かないように）。

## 確認したこと

- Chromium で light / dark 両方をスクリーンショット確認
- 上記の行数・スクロール有無・シェブロン挙動を DOM 計測で確認
- `tsc --noEmit` / `next lint`（新規の警告なし）/ `next build` → `✓ Compiled successfully`

なお `scrollbar-width: thin` と `scrollbar-color` が要素に効いていることは computed style で確認したが、Linux の headless Chromium はオーバーレイスクロールバー固定のため、バー自体の見た目はスクリーンショットでは検証できていない。

## アーキテクチャ

変更なし。新しいデータの置き場も外部依存も増やしていない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkEuBdqbN4JcbxBuPooXg6)_