### PR TITLE
feat: 記事本文にSVG図解を差し込む :::figure 記法を追加

### DIFF
--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { getDetail, getList, Blog } from '../../../../libs/notion';
 import { md, escapeHtml } from '@/lib/markdown';
 import { stripEmoji } from '@/lib/emoji';
+import { FIGURE_PATTERN, renderFigure } from '@/figures';
 import '../../../../styles/markdown.css';
 import '../../../../styles/hljs-theme.css';
 // KaTeX の CSS は数式の有無に関わらず記事ページで読み込まれる（約23KB、gzipで7KB程度）。
@@ -87,6 +88,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   // markdown->平文（Edge互換）
   const cleanBody = blog.body
+    .replace(/:::figure\{[^}]*\}/g, '')
     .replace(/:::callout\{[^}]*\}/g, '')
     .replace(/:::/g, '');
   const rawHtml = md.render(cleanBody);
@@ -203,10 +205,32 @@ export default async function StaticDetailPage({
     }
   );
 
-  const html = md.render(bodyPreprocessed);
+  // 図解マーカー `:::figure{id="..."}` をプレースホルダーに変換
+  // （SVGをそのままmarkdown-itに通すと整形で壊れるため、レンダリング後に差し込む）
+  const figureMap = new Map<string, string>();
+  let figureIndex = 0;
+  const bodyWithFigures = bodyPreprocessed.replace(
+    FIGURE_PATTERN,
+    (marker: string, id: string) => {
+      const figureHtml = renderFigure(id);
+      if (!figureHtml) return marker; // 未定義のidはマーカーを残す（記事側の誤記に気づけるように）
+      const placeholder = `FIGURE_PLACEHOLDER_${figureIndex++}`;
+      figureMap.set(placeholder, figureHtml);
+      return placeholder;
+    }
+  );
+
+  const html = md.render(bodyWithFigures);
 
   // プレースホルダーをcallout HTMLに置換
   let processedHtml = html;
+
+  figureMap.forEach((figureHtml, placeholder) => {
+    processedHtml = processedHtml.replace(
+      new RegExp(`<p>${placeholder}</p>|${placeholder}`, 'g'),
+      figureHtml
+    );
+  });
   calloutMap.forEach(({ icon, color, text }, placeholder) => {
     // テキスト先頭の絵文字がiconと重複する場合は除去
     const cleanText = text.replace(/^[\u{1F300}-\u{1F9FF}\u{2600}-\u{27BF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]+\s*/u, '').trim();

--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -44,6 +44,7 @@ function extractHeadings(html: string): { text: string; id: string; tag: string 
 }
 import type { Metadata, ResolvingMetadata } from 'next';
 import { StickyTableOfContents } from '@/components/TableOfContents/StickyTableOfContents';
+import { TocRail } from '@/components/TableOfContents/TocRail';
 import { RelatedPosts } from '@/components/RelatedPosts/RelatedPosts';
 import { ShareButtons } from '@/components/ShareButtons/ShareButtons';
 import { BreadcrumbNav } from '@/components/Breadcrumb/BreadcrumbNav';
@@ -617,13 +618,10 @@ export default async function StaticDetailPage({
               目次だけを sticky にすると、その下に置いた導線は通常フローに残って
               すぐ画面外に流れてしまい、記事を読み終えた頃には見えない。
               スクロールも1本にまとめる（入れ子のスクロール領域は操作しづらい）。 */}
-          <div
-            data-toc-rail
-            className='scrollbar-slim sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto overscroll-contain rounded-lg bg-white/50 p-4 backdrop-blur-sm dark:bg-slate-900/50'
-          >
+          <TocRail>
             <StickyTableOfContents toc={toc} />
             <ArticleAside blog={blog} latest={navPosts.filter((p) => p.id !== blogId).slice(0, 5)} />
-          </div>
+          </TocRail>
         </div>
       </div>
     </>

--- a/src/components/TableOfContents/TocRail.tsx
+++ b/src/components/TableOfContents/TocRail.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * 目次と回遊導線をまとめた sticky なレール。
+ *
+ * 中身が入りきらないときはレールごとスクロールするが、端が切り立ったままだと
+ * 「まだ続きがある」ことが見た目から分からない。隠れている側の端だけを
+ * フェードさせて、スクロールできることを示す。
+ *
+ * 両端とも見切れていないときはマスクを全面不透明にする。常にフェードさせると
+ * 最後までスクロールしたのに末尾が薄いままで、読み終えた感じが出ない。
+ */
+export const TocRail = ({ children }: { children: React.ReactNode }) => {
+  const railRef = useRef<HTMLDivElement>(null);
+  const [fade, setFade] = useState({ top: false, bottom: false });
+
+  const update = useCallback(() => {
+    const el = railRef.current;
+    if (!el) return;
+    const { scrollTop, scrollHeight, clientHeight } = el;
+    // 1px 未満の端数でフェードが点滅しないよう、少し余裕を持たせる
+    setFade({
+      top: scrollTop > 4,
+      bottom: scrollTop + clientHeight < scrollHeight - 4,
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = railRef.current;
+    if (!el) return;
+    update();
+
+    // 目次の開閉や回遊導線の読み込みで高さが変わるため、
+    // リサイズだけでなく中身の変化も見る。
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    for (const child of Array.from(el.children)) observer.observe(child);
+    return () => observer.disconnect();
+  }, [update]);
+
+  const mask = `linear-gradient(to bottom, ${
+    fade.top ? 'transparent 0, #000 20px' : '#000 0'
+  }, ${fade.bottom ? '#000 calc(100% - 28px), transparent 100%' : '#000 100%'})`;
+
+  return (
+    <div
+      ref={railRef}
+      data-toc-rail
+      onScroll={update}
+      className='scrollbar-slim sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto overscroll-contain rounded-lg bg-white/50 p-4 backdrop-blur-sm dark:bg-slate-900/50'
+      style={{ maskImage: mask, WebkitMaskImage: mask }}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/figures/index.ts
+++ b/src/figures/index.ts
@@ -1,0 +1,163 @@
+/**
+ * 記事本文に埋め込む図解（SVG）の定義。
+ *
+ * Notion 記事本文に `:::figure{id="gatekeeper-keys"}` と1行書くと、
+ * blogs/[blogId]/page.tsx がここの SVG に差し替える。
+ *
+ * ルール:
+ * - 色は直書きせず、markdown.css の CSS 変数を参照するクラス（fig-*）を使う。
+ *   これでブログのライト/ダーク切り替えにそのまま追従する。
+ * - 文字は 11〜13px 相当。説明文は図に入れず caption に書く。
+ * - <style> や <script> は入れない（本文 HTML にそのまま挿入されるため）。
+ */
+
+export type Figure = {
+  /** 図の下に出る説明。 */
+  caption: string;
+  /** SVG 本体。読み上げ用の説明は svg の aria-label に書く。 */
+  svg: string;
+};
+
+const arrowDefs = (idPrefix: string) => `
+  <defs>
+    <marker id="${idPrefix}-ink" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"></path>
+    </marker>
+    <marker id="${idPrefix}-deny" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="fig-f-deny"></path>
+    </marker>
+    <marker id="${idPrefix}-allow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="fig-f-allow"></path>
+    </marker>
+  </defs>`;
+
+export const figures: Record<string, Figure> = {
+  'gatekeeper-keys': {
+    caption:
+      '鍵の置き場所が変わるだけで、事故の上限が変わる。門番は「リポジトリAのイシューは読める／ソースコードは読めない／プルリクの統合は人間の承認が要る」といった粒度で線を引ける。',
+    svg: `<svg viewBox="0 0 760 330" role="img" aria-label="従来はAIエージェントがAPIキーを直接持ち外部サービスの全権限に届くのに対し、Cloudflare OSでは鍵をGatekeeperが保持し、エージェントは限定された操作だけを依頼できるという対比図">
+      ${arrowDefs('gk')}
+      <line x1="380" y1="20" x2="380" y2="310" stroke="currentColor" stroke-width="1" stroke-dasharray="3 5" opacity=".3"></line>
+
+      <text x="30" y="38" class="fig-t-deny fig-label">これまで</text>
+
+      <rect x="30" y="60" width="150" height="58" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="105" y="85" text-anchor="middle" font-size="13" fill="currentColor">AIエージェント</text>
+      <text x="105" y="104" text-anchor="middle" font-size="11.5" class="fig-t-deny">🔑 APIキーを保持</text>
+
+      <line x1="105" y1="118" x2="105" y2="188" class="fig-s-deny" stroke-width="2" marker-end="url(#gk-deny)"></line>
+      <text x="117" y="158" font-size="11.5" class="fig-t-deny">全権限で直接呼ぶ</text>
+
+      <rect x="30" y="190" width="300" height="58" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="180" y="215" text-anchor="middle" font-size="13" fill="currentColor">外部サービス（GitHub / Google / Slack …）</text>
+      <text x="180" y="234" text-anchor="middle" font-size="11.5" fill="currentColor" opacity=".72">できることは、キーの権限すべて</text>
+
+      <text x="30" y="285" font-size="11.5" class="fig-t-deny">誤作動・乗っ取り = 鍵の権限がそのまま実行される</text>
+
+      <text x="420" y="38" class="fig-t-allow fig-label">Cloudflare OS</text>
+
+      <rect x="420" y="60" width="150" height="58" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="495" y="85" text-anchor="middle" font-size="13" fill="currentColor">AIエージェント</text>
+      <text x="495" y="104" text-anchor="middle" font-size="11.5" fill="currentColor" opacity=".72">鍵を持たない</text>
+
+      <line x1="495" y1="118" x2="495" y2="148" stroke="currentColor" stroke-width="2" marker-end="url(#gk-ink)"></line>
+      <text x="507" y="139" font-size="11.5" fill="currentColor">「イシュー一覧を出して」</text>
+
+      <rect x="420" y="150" width="300" height="58" rx="3" fill="none" class="fig-s-allow" stroke-width="2"></rect>
+      <text x="570" y="175" text-anchor="middle" font-size="13" class="fig-t-allow">Gatekeeper（門番）</text>
+      <text x="570" y="194" text-anchor="middle" font-size="11.5" class="fig-t-allow">🔑 鍵はここ / 範囲を検査 / 記録を残す</text>
+
+      <line x1="495" y1="208" x2="495" y2="248" class="fig-s-allow" stroke-width="2" marker-end="url(#gk-allow)"></line>
+      <text x="507" y="233" font-size="11.5" class="fig-t-allow">許可された1リポジトリだけ</text>
+
+      <rect x="420" y="250" width="300" height="46" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="570" y="278" text-anchor="middle" font-size="13" fill="currentColor">外部サービス</text>
+    </svg>`,
+  },
+
+  'observation-log': {
+    caption:
+      '成果物は「どのデータから生まれたか」を忘れない。共有のたびに、受け取る側の権限が元データに対して問い直される。',
+    svg: `<svg viewBox="0 0 760 245" role="img" aria-label="エージェントが機密テーブルを読んで作ったダッシュボードには読んだ記録が付随し、権限のない同僚が開こうとするとGatekeeperが再検証して表示を止める流れの図">
+      ${arrowDefs('ob')}
+
+      <rect x="24" y="60" width="130" height="56" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="89" y="84" text-anchor="middle" font-size="12.5" fill="currentColor">機密テーブル</text>
+      <text x="89" y="102" text-anchor="middle" font-size="11" fill="currentColor" opacity=".72">Aさんだけ閲覧可</text>
+
+      <line x1="154" y1="88" x2="212" y2="88" stroke="currentColor" stroke-width="1.8" marker-end="url(#ob-ink)"></line>
+      <text x="183" y="78" text-anchor="middle" font-size="11" fill="currentColor">読む</text>
+
+      <rect x="214" y="60" width="120" height="56" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="274" y="92" text-anchor="middle" font-size="12.5" fill="currentColor">エージェント</text>
+
+      <line x1="334" y1="88" x2="392" y2="88" stroke="currentColor" stroke-width="1.8" marker-end="url(#ob-ink)"></line>
+      <text x="363" y="78" text-anchor="middle" font-size="11" fill="currentColor">作る</text>
+
+      <rect x="394" y="50" width="160" height="76" rx="3" fill="none" class="fig-s-accent" stroke-width="2"></rect>
+      <text x="474" y="76" text-anchor="middle" font-size="12.5" fill="currentColor">ダッシュボード</text>
+      <text x="474" y="97" text-anchor="middle" font-size="11" class="fig-t-accent">観測記録が付随</text>
+      <text x="474" y="114" text-anchor="middle" font-size="11" class="fig-t-accent" opacity=".85">「機密テーブルを見た」</text>
+
+      <line x1="554" y1="88" x2="612" y2="88" stroke="currentColor" stroke-width="1.8" marker-end="url(#ob-ink)"></line>
+      <text x="583" y="78" text-anchor="middle" font-size="11" fill="currentColor">共有</text>
+
+      <rect x="614" y="60" width="120" height="56" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="674" y="84" text-anchor="middle" font-size="12.5" fill="currentColor">同僚Bさん</text>
+      <text x="674" y="102" text-anchor="middle" font-size="11" fill="currentColor" opacity=".72">権限なし</text>
+
+      <path d="M 674 126 L 674 166 L 474 166 L 474 142" fill="none" class="fig-s-deny" stroke-width="1.8" marker-end="url(#ob-deny)"></path>
+      <text x="474" y="190" text-anchor="middle" font-size="11.5" class="fig-t-deny">開こうとした瞬間、Gatekeeperが元データへの権限を再検証</text>
+      <text x="474" y="210" text-anchor="middle" font-size="11.5" class="fig-t-deny">→ 権限がなければ中身は出てこない</text>
+    </svg>`,
+  },
+
+  'figure-pipeline': {
+    caption:
+      'SVG は markdown-it を通さない。プレースホルダーに退避しておき、本文が HTML になったあとで差し戻す。これで整形に壊されず、色だけ CSS 変数に委ねられる。',
+    svg: `<svg viewBox="0 0 720 450" role="img" aria-label="Notionに1行書いた図解マーカーが、Markdown化・プレースホルダーへの退避・markdown-itによるHTML化・SVGへの差し戻しという順で処理され、最終的にテーマ追従するfigureになるまでの流れ図">
+      ${arrowDefs('pl')}
+
+      <rect x="40" y="16" width="300" height="56" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="190" y="40" text-anchor="middle" font-size="12.5" fill="currentColor">Notion の本文に 1 行</text>
+      <text x="190" y="59" text-anchor="middle" font-size="11" class="fig-t-accent fig-label">:::figure{id="..."}</text>
+
+      <line x1="190" y1="72" x2="190" y2="104" stroke="currentColor" stroke-width="1.8" marker-end="url(#pl-ink)"></line>
+      <text x="360" y="94" font-size="11.5" fill="currentColor" opacity=".8">libs/notion.ts が Markdown 化</text>
+
+      <rect x="40" y="106" width="300" height="46" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="190" y="134" text-anchor="middle" font-size="12.5" fill="currentColor">Markdown 文字列</text>
+
+      <line x1="190" y1="152" x2="190" y2="184" stroke="currentColor" stroke-width="1.8" marker-end="url(#pl-ink)"></line>
+      <text x="360" y="174" font-size="11.5" fill="currentColor" opacity=".8">SVG は通さず、印だけ残して退避</text>
+
+      <rect x="40" y="186" width="300" height="46" rx="3" fill="none" class="fig-s-allow" stroke-width="2"></rect>
+      <text x="190" y="214" text-anchor="middle" font-size="12" class="fig-t-allow fig-label">FIGURE_PLACEHOLDER_0</text>
+
+      <line x1="190" y1="232" x2="190" y2="264" stroke="currentColor" stroke-width="1.8" marker-end="url(#pl-ink)"></line>
+      <text x="360" y="254" font-size="11.5" fill="currentColor" opacity=".8">markdown-it が本文を HTML 化</text>
+
+      <rect x="40" y="266" width="300" height="46" rx="3" fill="none" stroke="currentColor" stroke-width="1.5"></rect>
+      <text x="190" y="294" text-anchor="middle" font-size="12.5" fill="currentColor">HTML（印はそのまま残る）</text>
+
+      <line x1="190" y1="312" x2="190" y2="344" stroke="currentColor" stroke-width="1.8" marker-end="url(#pl-ink)"></line>
+      <text x="360" y="334" font-size="11.5" fill="currentColor" opacity=".8">印を SVG に差し戻す</text>
+
+      <rect x="40" y="346" width="300" height="64" rx="3" fill="none" class="fig-s-accent" stroke-width="2"></rect>
+      <text x="190" y="372" text-anchor="middle" font-size="12.5" fill="currentColor">figure + SVG</text>
+      <text x="190" y="392" text-anchor="middle" font-size="11" class="fig-t-accent">色は CSS 変数 → ライト / ダークに追従</text>
+    </svg>`,
+  },
+};
+
+/**
+ * 本文中の `:::figure{id="..."}` にマッチする。
+ * 独立した1行だけを対象にするので、文中でこの記法自体を引用しても置換されない。
+ */
+export const FIGURE_PATTERN = /^:::figure\{id="([^"]+)"\}[ \t]*$/gm;
+
+export function renderFigure(id: string): string | null {
+  const fig = figures[id];
+  if (!fig) return null;
+  return `<figure class="figure"><div class="figure-scroll">${fig.svg}</div><figcaption>${fig.caption}</figcaption></figure>`;
+}

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -1095,3 +1095,85 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.9em;
 }
+
+/* ------------------------------------------------------------------
+   図解 UI（本文の `:::figure{id="..."}` から生成）
+   SVG側は色を直書きせず、ここで定義した変数を参照するクラスを使う。
+   これでライト/ダークの切り替えにそのまま追従する。
+   ------------------------------------------------------------------ */
+.znc .figure {
+  margin: 2.5rem 0;
+  /* 図の意味色。ライト時 */
+  --fig-allow: #0b6355;
+  --fig-deny: #9b3226;
+  --fig-accent: #9a5d06;
+}
+.dark .znc .figure {
+  --fig-allow: #52bfa9;
+  --fig-deny: #e08578;
+  --fig-accent: #dfa455;
+}
+
+/* 狭い画面では図を縮めず、横スクロールさせる。
+   viewBox で縮めると図中の 11px の文字が読めなくなるため
+   （コードブロックやテーブルと同じ方針）。 */
+.znc .figure-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.znc .figure svg {
+  display: block;
+  width: 100%;
+  min-width: 540px;
+  height: auto;
+  padding: 1rem 0.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #334155;
+}
+.dark .znc .figure svg {
+  border-color: #334155;
+  background: #0b1220;
+  color: #cbd5e1;
+}
+
+.znc .figure figcaption {
+  margin-top: 0.85rem;
+  font-size: 0.9rem;
+  line-height: 1.8;
+  color: #64748b;
+}
+.dark .znc .figure figcaption {
+  color: #94a3b8;
+}
+
+/* 図中の小見出しラベル */
+.znc .figure .fig-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+}
+
+/* 意味色のクラス（fill / stroke） */
+.znc .figure .fig-t-allow,
+.znc .figure .fig-f-allow {
+  fill: var(--fig-allow);
+}
+.znc .figure .fig-t-deny,
+.znc .figure .fig-f-deny {
+  fill: var(--fig-deny);
+}
+.znc .figure .fig-t-accent {
+  fill: var(--fig-accent);
+}
+.znc .figure .fig-s-allow {
+  stroke: var(--fig-allow);
+}
+.znc .figure .fig-s-deny {
+  stroke: var(--fig-deny);
+}
+.znc .figure .fig-s-accent {
+  stroke: var(--fig-accent);
+}


### PR DESCRIPTION
## 概要

記事本文に `:::figure{id="..."}` の1行を置くと、`src/figures` に定義したSVG図解に差し替わるようにしました。SVG本体はコードとしてGit管理し、Notion側は1行書くだけで済みます。

画像(PNG)ではなくインラインSVGにしたのは、**ダークモードで図だけ真っ白に光る問題**を根本から避けるためです。色をCSS変数に逃がしてあるので、ライト/ダーク切替にそのまま追従します。

## 変更点

- **`src/figures/index.ts`（新規）**: idで引ける図解の定義。色は直書きせず `fig-*` クラスに逃がし、値は `markdown.css` のCSS変数で与える
- **`src/app/blogs/[blogId]/page.tsx`**: 既存の `:::callout` と同じプレースホルダー方式で差し込む。SVGをmarkdown-itに通すと整形で壊れるため、レンダリング後に差し戻す
- **`styles/markdown.css`**: `.figure` のスタイルとライト/ダーク両方のカラートークン
- **`src/components/TableOfContents/StickyTableOfContents.tsx`**: 目次が60vhを超えてスクロールするとき、隠れている側だけをフェード（上下どちらが見切れているかで出し分け）

## 設計上の判断

- **パターンは独立行限定**（`^...$` + `m`フラグ）。記事本文でこの記法自体を引用しても置換されないので、記法の解説記事が書ける
- **未定義idはマーカーを残す**。黙って図が消えるより、記事側の誤記に気づけるほうが安全
- **`generateMetadata` でもマーカーを除去**。OGP説明文に `figure{id=...}` が混入するのを防ぐ
- **狭い画面では図を縮めず横スクロール**（`min-width: 540px`）。viewBoxで縮めると図中の11pxの文字が読めなくなるため、既存のテーブルと同じ思想に揃えた

## 確認したこと

- `npx tsc --noEmit` / `npm run lint` ともにエラーなし（lintの警告は既存の `<img>` 関連のみ）
- ローカルで2記事を表示し、図・キャプション・コードブロック内の記法引用が意図どおり出ることを確認

## 既知の別件（このPRの対象外）

記事ページのコンソールにハイドレーション不一致のエラーが2件出ています。いずれも既存のもので、このPRとは無関係です。

1. next-themes が `<html>` に付ける `dark` クラス → `suppressHydrationWarning` で解消できます
2. `ShareButtons` が `navigator.share` の有無でサーバー/クライアント別の要素を出している

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt