### PR TITLE
feat: 連載記事の末尾に、続きを選べる横スライダーを置く

### DIFF
--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -59,6 +59,7 @@ import { KeyboardNav } from '@/components/KeyboardNav/KeyboardNav';
 import { FloatingTocButton } from '@/components/TableOfContents/FloatingTocButton';
 import { BookmarkButton } from '@/components/Bookmark/BookmarkButton';
 import { SeriesNav } from '@/components/Series/SeriesNav';
+import { SeriesCarousel } from '@/components/Series/SeriesCarousel';
 import { ArticleAside } from '@/components/ArticleAside/ArticleAside';
 import { ArticleSummary } from '@/components/ArticleSummary/ArticleSummary';
 import { ArticleChangelog } from '@/components/ArticleSummary/ArticleChangelog';
@@ -186,7 +187,15 @@ export default async function StaticDetailPage({
     : null;
 
   // 関連記事。タグの希少性で重み付けし、同じ連載を最優先する。
-  const related = relatedPosts(navPosts, blog);
+  // ただし連載の記事は記事末の SeriesCarousel で全部見せているので、候補から外す。
+  // 連載は他の何より高い重み付けなので、外さないと関連記事の3枠が
+  // カルーセルと同じ記事で埋まり、同じものが上下に2回並ぶ。
+  const related = relatedPosts(
+    navPosts,
+    blog,
+    3,
+    seriesContext ? new Set(seriesContext.series.posts.map((p) => p.id)) : undefined
+  );
 
   // 前後記事は連載内 → 同カテゴリ内 → 全体、の順で範囲を決める。
   // 全記事の公開日順だと React の記事の「次」が無関係なインフラ記事になる。
@@ -606,6 +615,20 @@ export default async function StaticDetailPage({
               const nextPost = idx > 0 ? navScope.posts[idx - 1] : null;
               return <KeyboardNav prevUrl={prevPost ? `/blogs/${prevPost.id}` : undefined} nextUrl={nextPost ? `/blogs/${nextPost.id}` : undefined} />;
             })()}
+            {/* 記事末の導線は、範囲が狭い順に「次の1本 → 前後 → 連載全体 → 連載外」。
+                連載は読者にとって一番強い文脈なので、関連記事より前に置く。 */}
+            {seriesContext && (
+              <SeriesCarousel
+                seriesName={seriesContext.series.name}
+                seriesHref={`/series/${encodeURIComponent(seriesContext.series.slug)}`}
+                posts={seriesContext.series.posts.map((p) => ({
+                  id: p.id,
+                  title: p.title,
+                  publishedAt: p.publishedAt,
+                }))}
+                currentIndex={seriesContext.index}
+              />
+            )}
             <RelatedPosts posts={related} currentPostId={blogId} />
           <FloatingTocButton toc={toc} />
           <FloatingShareButton title={blog.title} url={`${process.env.SITE_URL}/blogs/${blog.id}`} />

--- a/src/components/Series/SeriesCarousel.tsx
+++ b/src/components/Series/SeriesCarousel.tsx
@@ -1,0 +1,220 @@
+'use client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { Library, Check, ChevronLeft, ChevronRight, ArrowRight } from 'lucide-react';
+import { getReadArticles } from '@/lib/readArticles';
+
+export type SeriesCarouselPost = { id: string; title: string; publishedAt: string };
+
+type Props = {
+  seriesName: string;
+  seriesHref: string;
+  posts: SeriesCarouselPost[];
+  /** 現在表示中の記事の位置（0始まり） */
+  currentIndex: number;
+};
+
+/** 端が見切れているかの判定に持たせる余裕。1px未満の端数でフェードが点滅するのを防ぐ */
+const EDGE_EPSILON = 4;
+/**
+ * 端のフェードの幅(px)。
+ *
+ * scroll-padding にも同じ値を使う。こうしないと、Tab でフォーカスしたカードや
+ * スナップで止まったカードが端にぴったり付き、フェードの下に潜って
+ * フォーカスリングごと薄くなる。
+ */
+const EDGE_FADE = 24;
+
+/**
+ * 記事を読み終えた位置に置く、連載の横スライダー。
+ *
+ * 本文の前の SeriesNav は「今どこにいるか」を伝えるための縦の目次で、
+ * 読む前に全部を見せると本文に入るまでが長くなるため畳んだ見た目にしている。
+ * こちらは読み終えた読者に「次にどれを読むか」を選ばせるのが目的なので、
+ * 公開日まで載せたカードを横に並べて、一覧性より選びやすさを優先する。
+ *
+ * 既読の印は localStorage にしかないので Client Component。
+ * リンクとタイトルはサーバー側から props で受け取るので、
+ * JS が動かなくても「連載の記事へのリンクが横に並んだもの」としては成立する。
+ */
+export const SeriesCarousel = ({ seriesName, seriesHref, posts, currentIndex }: Props) => {
+  const scrollerRef = useRef<HTMLOListElement>(null);
+  const [read, setRead] = useState<string[]>([]);
+  // 「まだ続きがあるか」。矢印の活性とフェードの両方をこれ1つで決める。
+  // 別々に持つと、片方だけ更新し忘れて矢印は押せるのにフェードが消える状態になる。
+  const [overflow, setOverflow] = useState({ left: false, right: false });
+
+  useEffect(() => {
+    setRead(getReadArticles());
+  }, []);
+
+  const update = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    setOverflow({
+      left: scrollLeft > EDGE_EPSILON,
+      right: scrollLeft + clientWidth < scrollWidth - EDGE_EPSILON,
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+
+    // 連載の途中の記事から開くと、現在地が右端の外にいて見えないことがある。
+    // 現在地を左端に置くと、その右に「まだ読んでいない続き」が並ぶ。
+    // scrollIntoView はページ全体を縦に動かしてしまうので使わず、
+    // スライダーの scrollLeft だけを動かす。
+    // 位置は offsetLeft ではなく実際の矩形の差で測る。offsetLeft の基準は
+    // 最も近い position 付き祖先で、スライダー自身とは限らない。
+    const current = el.children[currentIndex] as HTMLElement | undefined;
+    if (current) {
+      el.scrollLeft +=
+        current.getBoundingClientRect().left - el.getBoundingClientRect().left - EDGE_FADE;
+    }
+    update();
+
+    // 画面幅が変わると見切れの有無も変わる。カードは幅固定なので
+    // 中身の変化まで見る必要はなく、スライダー自身のリサイズだけで足りる。
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [currentIndex, update]);
+
+  const scrollByCard = (direction: 1 | -1) => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const [first, second] = Array.from(el.children) as HTMLElement[];
+    // カード1枚ぶん送る。隙間を含めた実測の間隔を使うので、
+    // gap の値をコンポーネント側とCSS側の2箇所に書かずに済む。
+    const step = second ? second.offsetLeft - first.offsetLeft : (first?.offsetWidth ?? el.clientWidth);
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    el.scrollBy({ left: step * direction, behavior: reduceMotion ? 'auto' : 'smooth' });
+  };
+
+  // 連載に1本しかないときは横に並べるものがない。
+  // 「全1回」のスライダーは矢印も効かず、ただの重複した導線になる。
+  if (posts.length < 2) return null;
+
+  const mask = `linear-gradient(to right, ${
+    overflow.left ? `transparent 0, #000 ${EDGE_FADE}px` : '#000 0'
+  }, ${overflow.right ? `#000 calc(100% - ${EDGE_FADE}px), transparent 100%` : '#000 100%'})`;
+
+  return (
+    <section
+      aria-label={`連載「${seriesName}」の記事`}
+      className='mt-16 pt-8 px-4 border-t border-slate-200 dark:border-slate-700'
+    >
+      <div className='mb-4 flex items-center gap-3'>
+        <div className='flex min-w-0 items-center gap-2'>
+          <Library className='h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400' aria-hidden='true' />
+          <h2 className='truncate text-lg font-bold text-slate-900 dark:text-slate-100'>{seriesName}</h2>
+          <span className='shrink-0 text-sm text-slate-500 dark:text-slate-400'>全{posts.length}回</span>
+        </div>
+        <div className='ml-auto flex shrink-0 items-center gap-1'>
+          <button
+            type='button'
+            onClick={() => scrollByCard(-1)}
+            disabled={!overflow.left}
+            aria-label='前の記事を表示'
+            className='rounded-full border border-slate-200 p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:pointer-events-none disabled:opacity-30 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-700/50 dark:hover:text-slate-100'
+          >
+            <ChevronLeft className='h-4 w-4' aria-hidden='true' />
+          </button>
+          <button
+            type='button'
+            onClick={() => scrollByCard(1)}
+            disabled={!overflow.right}
+            aria-label='次の記事を表示'
+            className='rounded-full border border-slate-200 p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:pointer-events-none disabled:opacity-30 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-700/50 dark:hover:text-slate-100'
+          >
+            <ChevronRight className='h-4 w-4' aria-hidden='true' />
+          </button>
+        </div>
+      </div>
+
+      {/* 端のフェードは「まだ続きがある」ことを見た目で伝えるためのもの。
+          両端とも見切れていないときは全面不透明にする（TocRail と同じ考え方）。
+          カードは Tab でも辿れるので、フォーカスでスクロールしたときも
+          onScroll 経由でフェードと矢印の状態が追従する。 */}
+      <ol
+        ref={scrollerRef}
+        onScroll={update}
+        className='scrollbar-slim flex snap-x snap-mandatory gap-3 overflow-x-auto overscroll-x-contain pb-3'
+        style={{ maskImage: mask, WebkitMaskImage: mask, scrollPaddingInline: EDGE_FADE }}
+      >
+        {posts.map((post, i) => {
+          const isCurrent = i === currentIndex;
+          // 現在地には既読の印を出さない。今読んでいる記事にチェックが付くのは紛らわしい
+          const isRead = !isCurrent && read.includes(post.id);
+          const label = (
+            <>
+              <span className='flex items-center justify-between gap-2'>
+                <span
+                  className={`shrink-0 text-xs font-bold tabular-nums ${
+                    isCurrent ? 'text-blue-600 dark:text-blue-400' : 'text-slate-400 dark:text-slate-500'
+                  }`}
+                >
+                  第{i + 1}回
+                </span>
+                {isCurrent ? (
+                  <span className='shrink-0 rounded-full bg-blue-600 px-2 py-0.5 text-[10px] font-semibold text-white dark:bg-blue-500'>
+                    表示中
+                  </span>
+                ) : (
+                  isRead && (
+                    <span className='flex shrink-0 items-center gap-1 text-xs text-green-600 dark:text-green-500'>
+                      <Check className='h-3.5 w-3.5' aria-hidden='true' />
+                      読了
+                    </span>
+                  )
+                )}
+              </span>
+              <span className='mt-2 line-clamp-3 font-semibold text-slate-900 dark:text-slate-100'>
+                {post.title}
+              </span>
+              <time
+                dateTime={post.publishedAt}
+                className='mt-auto pt-3 text-xs text-slate-400 dark:text-slate-500'
+              >
+                {post.publishedAt.slice(0, 10).replace(/-/g, '/')}
+              </time>
+            </>
+          );
+
+          return (
+            <li key={post.id} className='w-60 shrink-0 snap-start sm:w-64'>
+              {isCurrent ? (
+                // 今いるページへのリンクは押しても何も起きない。
+                // リンクにせず「表示中」と明示して、選択肢から外す。
+                <span
+                  aria-current='page'
+                  className='flex h-full flex-col rounded-xl border border-blue-500 bg-blue-50 p-4 dark:bg-blue-950/40'
+                >
+                  {label}
+                </span>
+              ) : (
+                <Link
+                  href={`/blogs/${post.id}`}
+                  className='flex h-full flex-col rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-blue-400 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-blue-500'
+                >
+                  {label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      <Link
+        href={seriesHref}
+        className='mt-1 inline-flex items-center gap-1 text-sm text-slate-500 transition-colors hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'
+      >
+        この連載の一覧を見る
+        <ArrowRight className='h-3.5 w-3.5' aria-hidden='true' />
+      </Link>
+    </section>
+  );
+};

--- a/src/lib/related.ts
+++ b/src/lib/related.ts
@@ -22,8 +22,18 @@ const TAG_WEIGHT = 2;
 const RECENCY_WEIGHT = 1;
 const RECENCY_HORIZON_DAYS = 730;
 
-export function relatedPosts(all: Blog[], current: Blog, limit = 3): Blog[] {
-  const others = all.filter((p) => p.id !== current.id);
+/**
+ * @param excludeIds 候補から外す記事。別の枠（連載カルーセル等）で既に見せている記事を
+ *   重ねて出さないために使う。タグの希少度は `all` 全体から計算するので、
+ *   ここで除いてもスコアの尺度は変わらない。
+ */
+export function relatedPosts(
+  all: Blog[],
+  current: Blog,
+  limit = 3,
+  excludeIds?: ReadonlySet<string>
+): Blog[] {
+  const others = all.filter((p) => p.id !== current.id && !excludeIds?.has(p.id));
 
   // タグの出現数。希少なタグほど「関連している」という情報量が大きい
   const tagFreq = new Map<string, number>();


### PR DESCRIPTION
## なぜ

連載機能には本文前の `SeriesNav`（縦の目次）があるが、これは「今が何回目か」を読む前に伝えるためのもの。読み終えた読者が次の1本を選ぶ場所は記事末になく、あるのは「連載の次の記事」1件だけで、飛ばして別の回に行く導線がなかった。

## なにを

記事末に `SeriesCarousel` を追加し、連載の全記事をカードで横に並べた。

- 各カードに「第N回」「タイトル」「公開日」。**現在地はリンクにせず「表示中」と明示**する。押しても何も起きないリンクを選択肢に混ぜたくない
- 既読の記事にはチェックを付ける（既存の `getReadArticles()` を参照）。現在地には付けない — 今読んでいる記事に読了印が出るのは紛らわしい
- 左右の矢印で1枚ずつ送る。端では `disabled` にし、隠れている側の端だけを `mask-image` でフェードさせて続きの有無を示す（`TocRail` と同じ考え方）
- 連載が1本だけのときは何も出さない。連載に属さない記事では描画自体しない

## 設計上の判断

**置き場所は関連記事の直前。** 記事末の導線が「次の1本（連載の次） → 前後（PostNavigation） → 連載全体 → 連載外（関連記事）」と、範囲の狭い順に並ぶ。連載は読者にとって一番強い文脈なので、関連記事より前に置いた。

**関連記事から連載の記事を外した（`relatedPosts` に除外指定を追加）。** `SERIES_WEIGHT` は他の何より高いので、外さないと関連記事の3枠がカルーセルと同じ記事で埋まり、同じものが上下に2回並ぶ。タグの希少度は `all` 全体から計算したままなのでスコアの尺度は変わらない。連載外に候補がなければ既存のフォールバック（最新記事で埋める）が効く。

**送り幅はカードの実測間隔から取る。** `gap` の値をCSSとJSの2箇所に書くと片方だけずれる。

**初期位置は現在地を左端に。** その右に「まだ読んでいない続き」が並ぶ。`scrollIntoView` はページごと縦に動いてしまうので使わず `scrollLeft` を直接触る。位置は `offsetLeft` ではなく矩形の差で測っている（`offsetLeft` の基準は最も近い position 付き祖先で、スライダー自身とは限らない）。

**端の `scroll-padding` はフェードと同じ幅。** 入れないと Tab でフォーカスしたカードが端に貼り付き、フォーカスリングごとフェードで薄くなる。定数 `EDGE_FADE` から両方に渡している。

## アクセシビリティ

- 矢印は `<button>` + `aria-label`（「前の記事を表示」「次の記事を表示」）。端で `disabled`
- カードは `<Link>` なので Tab で辿れる。フォーカス移動でスライダーがスクロールし、矢印の活性とフェードも `onScroll` 経由で追従する
- 現在地は `aria-current="page"`、セクションは `aria-label="連載「○○」の記事"`
- `prefers-reduced-motion: reduce` のときはスムーススクロールを切る

## 確認したこと

`npx tsc --noEmit` / `npm run lint`（`<img>` の警告は既存のみ）/ `npm run build` いずれも通過。

`npm run dev` で実データ（連載「確定申告自動化」全6回）を使い、第3回の記事で確認した:

- 初期表示で現在地が左端（フェードの内側24px）に来る。「表示中」バッジと青枠で区別されている
- 左端で「前へ」が `disabled` かつ左フェードなし、右端まで送ると「次へ」が `disabled` かつ右フェードなし
- 矢印1回で1枚（268px）ぶん送られ、スナップ位置に収まる
- 最後のカードに `focus()` するとスライダーだけが末尾までスクロールし（ページは横に動かない）、矢印の活性が追従する
- `matchMedia` を差し替えて reduced-motion を装うと、スクロールが即座に完了する（通常は50ms時点でまだ途中）
- ライト/ダーク両方でスクリーンショット確認。1280px と 390px（カード幅 240px、ページ横スクロールの発生なし）
- 連載に属さない記事2本でカルーセルが出ないこと、200で返ることを確認
- 関連記事3枠に連載の記事が入らないことを確認

## 確認できていないこと

- 実機のタッチ操作でのスワイプ感（スナップの効き）は未検証。エミュレータ幅での見た目のみ
- 記事詳細の hydration エラーが dev で1件出るが、`ShareButtons` の native share 判定によるもので**このPRの変更とは無関係**（main でも出る）
- CI の `lighthouse` は本番サイトを計測するため fail する想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt