### PR TITLE
feat: 連載スライダーに説明を1行足し、記事末の区切り線を減らす

### DIFF
--- a/src/components/Series/SeriesCarousel.tsx
+++ b/src/components/Series/SeriesCarousel.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Library, Check, ChevronLeft, ChevronRight, ArrowRight } from 'lucide-react';
 import { getReadArticles } from '@/lib/readArticles';
+import { seriesMetaOf } from '@/lib/seriesMeta';
 
 export type SeriesCarouselPost = { id: string; title: string; publishedAt: string };
 
@@ -98,41 +99,58 @@ export const SeriesCarousel = ({ seriesName, seriesHref, posts, currentIndex }: 
   // 「全1回」のスライダーは矢印も効かず、ただの重複した導線になる。
   if (posts.length < 2) return null;
 
+  // 連載の説明は記事単位の Notion ではなくコード側（seriesMeta.ts）にある。
+  // 連載名から直接引けるので、記事ページ側に props を増やさずここで解決する。
+  const tagline = seriesMetaOf(seriesName)?.tagline;
+
   const mask = `linear-gradient(to right, ${
     overflow.left ? `transparent 0, #000 ${EDGE_FADE}px` : '#000 0'
   }, ${overflow.right ? `#000 calc(100% - ${EDGE_FADE}px), transparent 100%` : '#000 100%'})`;
 
+  // 上に区切り線を引かない。すぐ上の PostNavigation が線を持っているので、
+  // ここにも引くと「連載の次の記事 / 前後 / 連載全体」がそれぞれ罫線で囲まれ、
+  // 同じ連載の話が3つの別々のセクションに見える。
+  // 線は「連載の話」と「連載外（関連記事）」の境目の1本だけにする。
   return (
     <section
       aria-label={`連載「${seriesName}」の記事`}
-      className='mt-16 pt-8 px-4 border-t border-slate-200 dark:border-slate-700'
+      className='mt-12 px-4'
     >
-      <div className='mb-4 flex items-center gap-3'>
-        <div className='flex min-w-0 items-center gap-2'>
-          <Library className='h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400' aria-hidden='true' />
-          <h2 className='truncate text-lg font-bold text-slate-900 dark:text-slate-100'>{seriesName}</h2>
-          <span className='shrink-0 text-sm text-slate-500 dark:text-slate-400'>全{posts.length}回</span>
+      <div className='mb-4'>
+        <div className='flex items-center gap-3'>
+          <div className='flex min-w-0 items-center gap-2'>
+            <Library className='h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400' aria-hidden='true' />
+            <h2 className='truncate text-lg font-bold text-slate-900 dark:text-slate-100'>{seriesName}</h2>
+            <span className='shrink-0 text-sm text-slate-500 dark:text-slate-400'>全{posts.length}回</span>
+          </div>
+          <div className='ml-auto flex shrink-0 items-center gap-1'>
+            <button
+              type='button'
+              onClick={() => scrollByCard(-1)}
+              disabled={!overflow.left}
+              aria-label='前の記事を表示'
+              className='rounded-full border border-slate-200 p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:pointer-events-none disabled:opacity-30 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-700/50 dark:hover:text-slate-100'
+            >
+              <ChevronLeft className='h-4 w-4' aria-hidden='true' />
+            </button>
+            <button
+              type='button'
+              onClick={() => scrollByCard(1)}
+              disabled={!overflow.right}
+              aria-label='次の記事を表示'
+              className='rounded-full border border-slate-200 p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:pointer-events-none disabled:opacity-30 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-700/50 dark:hover:text-slate-100'
+            >
+              <ChevronRight className='h-4 w-4' aria-hidden='true' />
+            </button>
+          </div>
         </div>
-        <div className='ml-auto flex shrink-0 items-center gap-1'>
-          <button
-            type='button'
-            onClick={() => scrollByCard(-1)}
-            disabled={!overflow.left}
-            aria-label='前の記事を表示'
-            className='rounded-full border border-slate-200 p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:pointer-events-none disabled:opacity-30 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-700/50 dark:hover:text-slate-100'
-          >
-            <ChevronLeft className='h-4 w-4' aria-hidden='true' />
-          </button>
-          <button
-            type='button'
-            onClick={() => scrollByCard(1)}
-            disabled={!overflow.right}
-            aria-label='次の記事を表示'
-            className='rounded-full border border-slate-200 p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:pointer-events-none disabled:opacity-30 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-700/50 dark:hover:text-slate-100'
-          >
-            <ChevronRight className='h-4 w-4' aria-hidden='true' />
-          </button>
-        </div>
+        {/* 連載の説明は1行だけ。ここは「連載とは何か」を読ませる場所ではなく、
+            読み終えた読者が次の1本を選ぶ場所なので、全文を出すと選択の邪魔になる。
+            続きは「この連載の一覧を見る」の先にある。
+            未登録の連載では何も出さない（seriesMeta.ts に無くても壊れない）。 */}
+        {tagline && (
+          <p className='mt-1 line-clamp-1 text-sm text-slate-500 dark:text-slate-400'>{tagline}</p>
+        )}
       </div>
 
       {/* 端のフェードは「まだ続きがある」ことを見た目で伝えるためのもの。


### PR DESCRIPTION
## 1. 連載の説明（tagline）を見出し下に1行

#512 で入った `seriesMeta.ts` の tagline を、カルーセルの見出しの下に出した。連載カードの見出しは連載名だけで、その連載が何の話なのかは記事を開くまで分からなかった。

**1行に切っている（`line-clamp-1`）。** ここは「連載とは何か」を読ませる場所ではなく、読み終えた読者が次の1本を選ぶ場所なので、全文を出すと選択の邪魔になる。全文は「この連載の一覧を見る」の先にある。tagline が未登録の連載では何も出さない。

**tagline は連載名から `seriesMetaOf()` で直接引いている。** 記事ページ側に props を増やさずに済み、`src/app/blogs/[blogId]/page.tsx` を触らない（`perf/reduce-bundle` と競合させないため）。

代償として `SERIES_META` の文字列がクライアントバンドルに乗る: **記事ページの JS が 11.8kB → 12.3kB（+0.5kB）**、共有バンドルは 137kB のまま。バンドル削減が落ち着いた後なら、`page.tsx` から props で渡してサーバー側に戻すほうが筋は良い。切り替えは数行なので、そちらが良ければ言ってください。

## 2. カルーセル上の区切り線をやめた

記事末の導線を実際に縦に並べて見たところ、**この区間に区切り線が3本並び**、同じ連載の話が3つの別セクションに見えていた。すぐ上の `PostNavigation` が区切り線を持っているので、カルーセル側は引かないようにした。線は「連載の話」と「連載外（関連記事）」の境目の1本だけになる。

## 併せて報告: 「連載の次の記事」と PostNavigation が完全に重複しています

**このPRでは直していません**（削るのはナシと言われたため）。ただ、順序や言い回しでは解消できない性質のものなので、判断をお願いします。

第3回を開いたときの実際の並び:

| y座標 | 表示 | リンク先 |
|---|---|---|
| 9913 | 「連載の次の記事（4 / 6）」 | **第4回** |
| 10094 | PostNavigation「確定申告自動化 の次の記事」 | **第4回**（同じ） |
| 10388 | カルーセルの第4回カード | **第4回**（同じ） |

上2つは**同じ記事・同じタイトルのカードが約180px差で連続**しており、レイアウト崩れのようにも見えます。しかもこれは偶然ではなく構造的で、`navigationScope()` は連載記事なら連載内に絞る（`src/lib/related.ts:75-86`）ため、**PostNavigation の「次の記事」は常に `nextInSeries` と一致します**（連載が2本以上あれば必ず。最終回はどちらも出ないので、食い違うケースがありません）。

順序を入れ替えても言い回しを変えても、同じ記事が2枚出ること自体は変わりません。実質的な選択肢は次のどれかだと思います:

1. **`nextInSeries` ブロックを外す**（PostNavigation が連載スコープなので機能的に完全上位互換）— 一番素直
2. `navigationScope()` から連載の分岐を外し、PostNavigation は公開日順に戻す — ただし連載の順序が崩れるので反対
3. このまま残す

私の推しは 1 です。ただ `page.tsx` の編集になるので、`perf/reduce-bundle` が落ち着いてからのほうが安全です。

## 確認したこと

`npx tsc --noEmit` / `npm run lint`（`<img>` 警告は既存のみ）/ `npm run build` すべて通過。

実データで確認:

- 第3回（`/blogs/freee-api-ui-responsibility-split`）と第1回（`/blogs/tax-automation-claude-code-overview`）
- tagline が 1280px でも 390px でも**1行に収まる**（`line-clamp-1` が効いて末尾が省略される）ことを実測（行数 = 1）
- 第1回では左矢印が `disabled`、`scrollLeft` が 0 で始まる
- カルーセルの `border-top` が `0px` になり、区切り線が「関連記事の前」1本だけになったこと
- ライト/ダーク両方、390px 幅でページ横スクロールが発生しないこと

## 確認できていないこと

- tagline 未登録の連載での表示は、`SERIES_META` に登録済みの2連載しか無いため**実データでは確認できていません**（`seriesMetaOf()` が `undefined` を返し `{tagline && ...}` で落ちる経路なので、コード上は何も描画されません）
- 実機タッチでのスワイプ感は前回同様、未検証です
- dev の hydration エラー1件は `ShareButtons` 由来の既存問題で、このPRとは無関係です

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt