### PR TITLE
seo: 検索結果のタイトルからカテゴリ接頭辞を落とす

### DIFF
--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -105,22 +105,41 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const ogImage = blog.eyecatch?.url;
   const pageUrl = `${process.env.SITE_URL}/blogs/${blogId}`;
 
+  // 検索結果のタイトルは日本語で30文字ほどで切られる。そこに
+  // 「| kt-tech.blog」（14文字）が後ろから食い込むので、先頭に使える幅は
+  // 実質20文字を切る。「【設定・環境構築】Gemma 4 を Ollama で…」のように、
+  // その貴重な先頭をカテゴリ名が9文字前後占め、検索語に当たる部分が
+  // 省略記号の向こうへ押し出されていた。カテゴリは記事ページにチップとして
+  // 別に出しているので、メタ情報からは落とす。
+  //
+  // ただし落とすのは【】の中身が**カテゴリ名と一致するときだけ**。
+  // 古い記事は【Ubuntu24.04LTS】【React × Github Pages】のように
+  // 技術名を【】に入れており、ここを機械的に削ると検索語そのものが
+  // タイトルから消える（この2本は流入の上位を占めている）。
+  //
+  // ページ内の見出し（h1）や一覧の表示は blog.title のままなので、見た目は変わらない。
+  const categoryPrefix = blog.category?.name ? `【${blog.category.name}】` : null;
+  const metaTitle =
+    categoryPrefix && blog.title.startsWith(categoryPrefix)
+      ? blog.title.slice(categoryPrefix.length).trim()
+      : blog.title;
+
   return {
-    title: blog.title,
+    title: metaTitle,
     description,
     alternates: {
       canonical: pageUrl,
     },
     twitter: {
       card: 'summary_large_image' as const,
-      title: blog.title,
+      title: metaTitle,
       description,
       site: '@tech_koki',
       creator: '@tech_koki',
       ...(ogImage ? { images: [ogImage] } : {}),
     },
     openGraph: {
-      title: blog.title,
+      title: metaTitle,
       description,
       locale: 'ja_JP',
       type: 'article' as const,


### PR DESCRIPTION
## 背景（Search Console の実データ）

直近3か月の実績を見ると、**検索結果に出ているのにクリックされていない記事**があります。

| 記事 | 表示回数 | クリック | CTR |
|---|---|---|---|
| Gemma 4 を Ollama で… | **1,972**（サイト2位） | 44 | **2.2%** |
| browser-use v2 CLI を… | 1,071 | 22 | **2.1%** |

サイト平均CTRは4.1%なので、この2本は明確に見劣りします。

## 原因

検索結果のタイトルは日本語で**30文字ほどで切られます**。そこに `| kt-tech.blog` が後ろから14文字食い込むため、先頭に使える幅は実質20文字を切ります。

```
【設定・環境構築】Gemma 4 を Ollama でローカル起動して OpenClaw と接続する | kt-tech.blog
^^^^^^^^^^^^^^^^^ ここで9文字
→ 表示は「【設定・環境構築】Gemma 4 を Ollama でローカル起動し…」
```

**検索語に当たる「Gemma 4」「Ollama」が、9文字のカテゴリ名に押されて後ろに来ています。** カテゴリは記事ページにチップとして別に出しているので、メタ情報に持つ必要がありません。

## 変更

`generateMetadata` のタイトルからカテゴリ接頭辞を落とします。`title` / `openGraph.title` / `twitter.title` の3か所。

### 一律除去は事故になるので避けた

最初 `replace(/^【[^】]*】/, '')` で実装しかけましたが、実データで検証して**危険と分かったのでやめました**。

```
【Ubuntu24.04LTS】DNS永続化設定        → DNS永続化設定        ← Ubuntu が消える
【React × Github Pages】自己紹介サイト → 簡単に自己紹介サイト  ← React が消える
```

古い記事は【】に**技術名**を入れています。そしてこの2本は、**サイト流入の上位**です（288クリック=全体の47%、47クリック）。機械的に削ると検索語そのものがタイトルから消え、大きく損なうところでした。

そこで **`【` + カテゴリ名 + `】` に完全一致するときだけ落とす**実装にしています。

### 影響範囲（公開84記事で検証済み）

| 接頭辞 | カテゴリ | 件数 | 結果 |
|---|---|---|---|
| 【実装】【設計】【トラブルシューティング】【設定・環境構築】【学習メモ】 | 一致 | **49件** | 除去 |
| 【Ubuntu24.04LTS】【React × Github Pages】【Next.js】【AWS】【Github】など | 不一致 | **32件** | そのまま |
| 【実践】【自動化】【移行ガイド】【SEO】など記事タイプ系 | 不一致 | 上記に含む | そのまま（安全側） |

**サイトの見た目は変わりません。** ページ内の見出し(h1)も一覧の表示も `blog.title` のままで、変わるのは `<title>` とOGPだけです。

## リスク

タイトル変更は検索順位に影響しうるので、効果は数週間後にSearch Consoleで確認する必要があります。ただし今回は「キーワードを前に出す」方向の変更であり、キーワードを失う記事は1件もないことを実データで確認済みです。ロールバックもこの1ファイルを戻すだけです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt