### PR TITLE
fix: 記事末で同じ記事のカードが2枚並ぶのをやめる

### DIFF
--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -201,9 +201,6 @@ export default async function StaticDetailPage({
 
   // 連載。連載名と順序は Notion のプロパティで持つので、新しい保存先は増やしていない。
   const seriesContext = findSeriesOf(navPosts, blog);
-  const nextInSeries = seriesContext
-    ? seriesContext.series.posts[seriesContext.index + 1] ?? null
-    : null;
 
   // 関連記事。タグの希少性で重み付けし、同じ連載を最優先する。
   // ただし連載の記事は記事末の SeriesCarousel で全部見せているので、候補から外す。
@@ -542,7 +539,7 @@ export default async function StaticDetailPage({
               <ReadingTracker articleId={blogId} />
             </div>
             {blog.changelog && <ArticleChangelog entries={blog.changelog} />}
-            {/* 記事末: タグ → シェア/著者/フィードバック → 前後記事 → 関連記事。
+            {/* 記事末: タグ → シェア/著者/フィードバック → 前後記事 → 連載 → 関連記事。
                 以前はシェアが記事上部と末尾の2箇所にあり、著者カードもリンク先がなかった。 */}
             {blog.tags && blog.tags.length > 0 && (
               <div className='mt-12 mx-4'>
@@ -605,26 +602,11 @@ export default async function StaticDetailPage({
                 </a>
               </div>
             </div>
-            {/* 連載の続きは公開日順の前後記事より優先して出す。
-                PostNavigation は公開日順なので、連載の間に別記事を挟むと順序が崩れる。 */}
-            {nextInSeries && seriesContext && (
-              <div className='mt-10 mx-4'>
-                <Link
-                  href={`/blogs/${nextInSeries.id}`}
-                  className='flex items-center gap-3 rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-blue-400 hover:bg-blue-50/50 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-blue-500 dark:hover:bg-slate-700/50'
-                >
-                  <span className='min-w-0 flex-1'>
-                    <span className='block text-xs text-slate-500 dark:text-slate-400'>
-                      連載の次の記事（{seriesContext.index + 2} / {seriesContext.series.posts.length}）
-                    </span>
-                    <span className='mt-0.5 block font-semibold text-slate-900 dark:text-slate-100'>
-                      {nextInSeries.title}
-                    </span>
-                  </span>
-                  <span aria-hidden='true' className='shrink-0 text-slate-400'>→</span>
-                </Link>
-              </div>
-            )}
+            {/* 連載の続きへの導線は PostNavigation に任せる。
+                navigationScope が連載記事を連載内に絞るので、PostNavigation の
+                「次の記事」は連載の次の回そのものになる（連載が2本以上なら必ず一致し、
+                最終回はどちらも出ない）。ここに専用のカードも置いていたため、
+                同じ記事の同じタイトルが約180px差で2枚続けて並んでいた。 */}
             <PostNavigation currentId={blogId} allPosts={navScope.posts} scopeLabel={navScope.label} />
             {(() => {
               // j/k のショートカットも前後記事ナビと同じ範囲を辿らせる。
@@ -634,7 +616,7 @@ export default async function StaticDetailPage({
               const nextPost = idx > 0 ? navScope.posts[idx - 1] : null;
               return <KeyboardNav prevUrl={prevPost ? `/blogs/${prevPost.id}` : undefined} nextUrl={nextPost ? `/blogs/${nextPost.id}` : undefined} />;
             })()}
-            {/* 記事末の導線は、範囲が狭い順に「次の1本 → 前後 → 連載全体 → 連載外」。
+            {/* 記事末の導線は、範囲が狭い順に「前後 → 連載全体 → 連載外」。
                 連載は読者にとって一番強い文脈なので、関連記事より前に置く。 */}
             {seriesContext && (
               <SeriesCarousel


### PR DESCRIPTION
## なぜ

連載記事の末尾に置いていた「連載の次の記事」カードと、そのすぐ下の `PostNavigation` の「次の記事」が、**必ず同じ記事を指していた**。同じタイトルのカードが約180px差で2枚続けて並び、レイアウト崩れのようにも見える状態だった。

これは偶然ではなく構造的なもの。`navigationScope()` は連載記事なら前後記事の範囲を連載内に絞る（`src/lib/related.ts:75-86`）ので、`PostNavigation` の「次の記事」は連載の次の回そのものになる。**連載が2本以上あれば必ず一致し、最終回はどちらも出ない**ため、両者が食い違うケースが存在しない。

順序を入れ替えても文言を変えても「同じ記事が2枚出る」こと自体は消せないので、専用カードのほうを外す。`PostNavigation` が連載スコープで動く以上、機能としては完全に含まれている。

連載の全体像は #513 の `SeriesCarousel` が受け持つので、「次の1本」への導線が痩せるわけではない。

## 変更

`src/app/blogs/[blogId]/page.tsx` の1ファイルのみ（-25 / +7 行）。

- `nextInSeries` の算出と、それを使う JSX ブロックを削除
- 記事末の並びを説明したコメント2箇所を実態に合わせて更新

**片付け漏れがないことを確認済み:**

- `nextInSeries` は全体検索して残存 0 件
- `Link` の import は著者カード（`/about`）でまだ使うので残す
- `src/lib/related.ts` は `relatedPosts` / `navigationScope` とも引き続き使用中。`relatedPosts` の除外指定（#513 で追加）も `SeriesCarousel` 側で使うので不要にならない

## 確認したこと

`npx tsc --noEmit` / `npm run lint` / `npm run build` すべて通過。バンドルサイズは 12.3 kB / 137 kB で変化なし。

実データで**4パターン**を確認した:

| 記事 | 旧カード | カルーセル | PostNav 前 | PostNav 次 |
|---|---|---|---|---|
| 第3回（途中） | なくなった | あり | あり | あり |
| **第6回（最終回）** | なくなった | あり | あり | なし（正） |
| 第1回 | なくなった | あり | なし（正） | あり |
| **連載外の記事** | — | 出ない（正） | あり | あり |

「Claude Code Harness」の4記事でも、旧カードが消えカルーセルが出ることを確認（全て 200）。

**導線が飛ばないことの確認:**

- **最終回**: `PostNavigation` は「前の記事」だけになるが、カルーセル（全6回・第6回が「表示中」・右矢印が `disabled`・左端がフェード）、「この連載の一覧を見る」、関連記事が残り、行き止まりにならない
- **連載外**: カルーセルは出ず、`PostNavigation` はカテゴリスコープ（「実装 の前/次の記事」）、関連記事も従来どおり。今回の変更の影響を受けない
- 記事末が約190px短くなり、「前後 → 連載全体 → 関連記事」と素直に並ぶようになった

## 確認できていないこと

- 実機タッチでの操作感は未検証
- dev の hydration エラー1件は `ShareButtons` 由来の既存問題で、このPRとは無関係
- CI の `next/font` フレークは既知（別途対応中とのこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt