### PR TITLE
fix: mermaid の矢印ラベルが読めないのを直す

### DIFF
--- a/src/components/Mermaid/MermaidRenderer.tsx
+++ b/src/components/Mermaid/MermaidRenderer.tsx
@@ -29,6 +29,18 @@ export const MermaidRenderer = () => {
           // 失敗時に mermaid が body 直下へ独自のエラー図を差し込むのを止める
           suppressErrorRendering: true,
           fontFamily: 'inherit',
+          themeVariables: {
+            // 矢印につけたラベルの下敷きの色。既定値は図の背景と揃っておらず、
+            // ラベルが線や隣のノードに重なって読めなくなっていた。
+            // .mermaid-block__figure の background と同じ値にする。
+            edgeLabelBackground: resolvedTheme === 'dark' ? '#0b1220' : '#ffffff',
+          },
+          flowchart: {
+            // 日本語のラベルは英字より横に伸びやすく、既定の折り返し幅だと
+            // ノードの枠から文字がはみ出して切れていた
+            wrappingWidth: 200,
+            useMaxWidth: true,
+          },
         });
 
         for (let i = 0; i < blocks.length; i += 1) {

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -441,6 +441,25 @@
   max-width: 100%;
   height: auto;
 }
+/* 矢印のラベル。mermaid 側の themeVariables でも下敷きの色を渡しているが、
+   バージョンによっては foreignObject の中の要素に効かないので、こちらでも塗る。
+   透明のままだと線や隣のノードに重なって読めない。 */
+.znc .mermaid-block__figure .edgeLabel,
+.znc .mermaid-block__figure .edgeLabel p,
+.znc .mermaid-block__figure .edgeLabel span {
+  background-color: #ffffff;
+  color: #334155;
+}
+.dark .znc .mermaid-block__figure .edgeLabel,
+.dark .znc .mermaid-block__figure .edgeLabel p,
+.dark .znc .mermaid-block__figure .edgeLabel span {
+  background-color: #0b1220;
+  color: #cbd5e1;
+}
+/* ラベルの文字が線に触れて読みにくいので、下敷きに少し余白を持たせる */
+.znc .mermaid-block__figure .edgeLabel p {
+  padding: 0 0.25em;
+}
 .znc .mermaid-block.is-rendered .mermaid-block__source {
   display: none;
 }


### PR DESCRIPTION
## 症状

過去記事に図解を入れる作業を始めたところ、**mermaid の矢印につけたラベルが読めない**ことが分かりました。ラベルの下敷きの色が図の背景と揃っておらず、線や隣のノードに重なります。

あわせて、**日本語のノードラベルが枠から溢れて切れる**現象も出ています（「netplan の設定ファイル /etc/netplan/01-」で途切れる）。

## 原因

- `edgeLabelBackground` が既定値のままで、`.mermaid-block__figure` の背景（ライト `#ffffff` / ダーク `#0b1220`）と一致していない
- `flowchart.wrappingWidth` が未指定。既定の折り返し幅は英字前提なので、横に伸びやすい日本語ラベルがノード幅を超える

## 変更

1. `themeVariables.edgeLabelBackground` に図の背景と同じ色を渡す（ライト/ダークで切り替え）
2. mermaid のバージョンによっては `foreignObject` の中まで効かないため、**CSS でも `.edgeLabel` を塗る**（保険）。ラベルの左右に少し padding も入れて線に触れないようにする
3. `flowchart.wrappingWidth: 200` を指定

## なぜ描画側で直すか

個別の図を短く書けば回避はできますが、**過去記事に図解を足していく作業をこれから進める**ので、記事ごとに気をつけるのではなく描画側で揃えておくべきと判断しました。

## 確認

- `npx tsc --noEmit` エラーなし
- 変更は mermaid の描画設定とそのCSSに閉じており、図を含まない記事には影響しません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt