### PR TITLE
design: 表が背景に溶けて崩れて見えるのを直す

### DIFF
--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -2,10 +2,14 @@
    以前は赤み寄りのグレーで、サイト全体の slate（青みグレー）と並ぶと色が濁って見えていた。 */
 :root {
   --md-code-bg-light: 241 245 249; /* slate-100 */
-  --md-table-th-light: #f8fafc; /* slate-50 */
+  /* 見出し行は本文の地とはっきり差をつける。slate-50 では白背景との差が
+     ほとんどなく、ヘッダーがどこまでか分からなくなっていた */
+  --md-table-th-light: #eef2f7;
   --md-table-td-light: transparent;
   --md-code-bg-dark: 51 65 85; /* slate-700 */
-  --md-table-th-dark: #1e293b; /* slate-800 */
+  /* ダークは特に差が出にくい。本文の地(slate-900系)に対して #1e293b では
+     ほぼ同色に見え、表全体が背景に溶けて崩れているように見えていた */
+  --md-table-th-dark: #253349;
   --md-table-td-dark: transparent;
 }
 
@@ -721,24 +725,27 @@
   padding: 0.625rem 0.875rem;
   text-align: left;
   font-weight: 600;
-  border-bottom: 1px solid #e2e8f0;
+  /* 見出し行と本文の境目は他の罫線より太くする。同じ太さだと
+     どこまでがヘッダーなのか読み取れない */
+  border-bottom: 2px solid #cbd5e1;
 }
 
 .dark .znc th {
   background: var(--md-table-th-dark);
-  border-bottom-color: #334155;
+  border-bottom-color: #3b4d6b;
 }
 
 .znc td {
   padding: 0.625rem 0.875rem;
   background: var(--md-table-td-light);
   color: hsl(var(--foreground));
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid #e2e8f0;
 }
 
 .dark .znc td {
   background: var(--md-table-td-dark);
-  border-bottom-color: #1e293b;
+  /* 罫線が縞模様の背景と同色だと線として見えない */
+  border-bottom-color: #2b3a52;
 }
 
 .znc tbody tr:last-child td {
@@ -750,7 +757,8 @@
   background: #f8fafc;
 }
 .dark .znc tbody tr:nth-child(even) td {
-  background: rgba(30, 41, 59, 0.5);
+  /* 半透明だと下の地の色に左右されて、縞が出たり出なかったりする */
+  background: #1a2434;
 }
 .znc tbody tr:hover td {
   background: #f1f5f9;


### PR DESCRIPTION
## 症状

ダークで記事の表を見ると、**ヘッダーと本文の境目が分からず、行の区切りも見えず、表全体が背景に溶けて「崩れている」ように見える**という指摘がありました。

## 原因

色の差が足りていませんでした。特に決定的なのは**罫線と背景が同色**だったことです。線は引かれているのに見えないので、セルの区切りが消えます。

| 要素 | 変更前 | 問題 |
|---|---|---|
| 見出し行の背景 | `#1e293b` | 本文の地（slate-900系）とほぼ同色 |
| 行の罫線 | `#1e293b` | **縞模様の背景と同じ色**で線として見えない |
| 縞模様 | `rgba(30,41,59,.5)` | 半透明で下の地に左右され、出たり出なかったりする |
| 見出しの下線 | 1px | 行間の罫線と同じ太さで、ヘッダーの終わりが分からない |

## 変更

- 見出し行の背景をはっきり差のある色に（ライト `#eef2f7` / ダーク `#253349`）
- 行の罫線を「線として見える」明るさに（ダーク `#2b3a52`）
- 縞模様を不透明色に（ダーク `#1a2434`）
- **見出し行の下だけ 2px** にして、ヘッダーの終わりが分かるように

ライト側も、`slate-50` では白背景との差がほとんど無かったので合わせて調整しています。

## 補足：記事側にも別の原因がありました

同じ表に `:-:` という中身のない行が混ざっていました。**Markdownの表区切り（`|:-:|:-:|`）が、microCMSからNotionへ移行したときにデータ行として取り込まれた残骸**です。こちらは記事側で個別に潰しています（このPRの対象外）。

## 確認

- `npx tsc --noEmit` エラーなし
- 変更は表のCSSに閉じています

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt