### PR TITLE
fix: 図解マーカーの閉じ `:::` が本文に出るのを止める

### DIFF
--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -246,7 +246,12 @@ export default async function StaticDetailPage({
     }
   );
 
-  const html = md.render(bodyWithFigures);
+  // Notion のエディタは `:::figure{...}` を独自記法のブロックとみなして、
+  // 閉じの `:::` を本文に残すことがある。callout は上でブロックごと消費しているので、
+  // ここに残る単独行の `:::` はその余りだけ。落とさないと段落として描画されてしまう。
+  const bodyWithoutStrayFence = bodyWithFigures.replace(/^:::[ \t]*$/gm, '');
+
+  const html = md.render(bodyWithoutStrayFence);
 
   // プレースホルダーをcallout HTMLに置換
   let processedHtml = html;


### PR DESCRIPTION
## 何が起きていたか

公開したばかりの記事「[Notionに1行書くだけでSVG図解を出す](https://kt-tech.blog/blogs/notion-blog-svg-figure-pipeline)」で、図解の直下にコロン3つの行が3つ並んで表示されていました。

```
（図解）
:::
:::
:::
## 実装
```

Notion のエディタが `:::figure{id="..."}` を独自記法のブロックとみなして、閉じの `:::` を本文に残すためです。Notion 側から消そうとしても復活するので、レンダリング側で落とします。

## 直し方

figure のプレースホルダー置換のあとに、単独行の `:::` を除去します。

callout は `:::callout{...}` 〜 `:::` を1つの正規表現でブロックごと消費しているため、この時点で残っている単独行の `:::` は figure の余りだけです。callout の閉じを巻き込む心配はありません。

`generateMetadata` 側は既に `.replace(/:::/g, '')` で全除去しているので変更していません。

## 確認

- `npx tsc --noEmit` 通過
- マージ後、公開ページの HTML に `<p>:::</p>` が残らないことを確認します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt