### PR TITLE
記事本文の強調を「太さ」から「濃さ」に変える

### DIFF
--- a/scripts/generate-eyecatch-thumbnails.mjs
+++ b/scripts/generate-eyecatch-thumbnails.mjs
@@ -1,0 +1,150 @@
+// 一覧カード用のサムネイルを R2 に用意するスクリプト。
+//
+// アイキャッチは 1376x768 / 約 58KB で R2 に置いてあり、記事ページのヒーローでは
+// その大きさが要る。一方カードでの表示は 96〜128px しかないのに、
+// next.config.js が `images.unoptimized: true`（Cloudflare Pages では
+// Next.js の画像最適化が動かない）なので、原寸がそのまま配信されていた。
+// Lighthouse の "Properly size images" が 426KB の削減余地を出していたのはこれ。
+//
+// ここでは既存のアイキャッチから幅 320px の版を作り、
+// `images/eyecatch/thumb/<name>.webp` として同じバケットに置く。
+// 参照側は src/lib/eyecatch.ts の thumbnailUrl() を使う。
+//
+//   node scripts/generate-eyecatch-thumbnails.mjs [--dry-run] [--force]
+//
+// --dry-run: 生成せず対象だけ表示する
+// --force  : 既にサムネイルがあっても作り直す
+
+import { S3Client, ListObjectsV2Command, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+import { readFileSync } from 'fs';
+
+// .env.local を手動パース（generate-eyecatch.mjs と同じ方式）
+const envFile = readFileSync('.env.local', 'utf-8');
+envFile.split('\n').forEach((line) => {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) return;
+  const idx = trimmed.indexOf('=');
+  if (idx === -1) return;
+  const key = trimmed.slice(0, idx).trim();
+  const val = trimmed.slice(idx + 1).trim();
+  if (key && val) process.env[key] = val;
+});
+
+const R2_ENDPOINT = process.env.R2_ENDPOINT;
+const R2_ACCESS_KEY = process.env.R2_ACCESS_KEY;
+const R2_SECRET_KEY = process.env.R2_SECRET_KEY;
+const BUCKET = process.env.NEXT_PUBLIC_BUCKET_NAME;
+const BUCKET_URL = process.env.NEXT_PUBLIC_R2_BUCKET_URL;
+
+for (const [name, value] of Object.entries({ R2_ENDPOINT, R2_ACCESS_KEY, R2_SECRET_KEY, BUCKET, BUCKET_URL })) {
+  if (!value) {
+    console.error(`.env.local に ${name} がありません`);
+    process.exit(1);
+  }
+}
+
+/** カード表示は 96〜128px。2倍解像度でも足りるように 320px にする */
+const THUMB_WIDTH = 320;
+const PREFIX = 'images/eyecatch/';
+const THUMB_PREFIX = 'images/eyecatch/thumb/';
+
+const dryRun = process.argv.includes('--dry-run');
+const force = process.argv.includes('--force');
+
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: R2_ENDPOINT,
+  credentials: { accessKeyId: R2_ACCESS_KEY, secretAccessKey: R2_SECRET_KEY },
+});
+
+async function listAll(prefix) {
+  const objects = [];
+  let token;
+  do {
+    const res = await s3.send(
+      new ListObjectsV2Command({ Bucket: BUCKET, Prefix: prefix, ContinuationToken: token })
+    );
+    objects.push(...(res.Contents || []));
+    token = res.NextContinuationToken;
+  } while (token);
+  return objects;
+}
+
+async function main() {
+  const all = await listAll(PREFIX);
+  const candidates = all.filter((o) => !o.Key.startsWith(THUMB_PREFIX) && /\.(webp|png|jpe?g)$/i.test(o.Key));
+
+  // 同じ名前で .png と .webp が両方残っている。サムネイルのキーはどちらも .webp に
+  // なって衝突するので、WebP がある名前は WebP だけを見る。
+  const byBaseName = new Map();
+  for (const obj of candidates) {
+    const base = obj.Key.slice(PREFIX.length).replace(/\.(webp|png|jpe?g)$/i, '');
+    const current = byBaseName.get(base);
+    if (!current || (/\.webp$/i.test(obj.Key) && !/\.webp$/i.test(current.Key))) {
+      byBaseName.set(base, obj);
+    }
+  }
+  const originals = [...byBaseName.values()];
+  const existingThumbs = new Set(all.filter((o) => o.Key.startsWith(THUMB_PREFIX)).map((o) => o.Key));
+
+  const targets = originals.filter((o) => {
+    const thumbKey = THUMB_PREFIX + o.Key.slice(PREFIX.length).replace(/\.(png|jpe?g)$/i, '.webp');
+    return force || !existingThumbs.has(thumbKey);
+  });
+
+  const totalOriginal = originals.reduce((a, o) => a + o.Size, 0);
+  console.log(`アイキャッチ ${originals.length} 枚 / 合計 ${(totalOriginal / 1024 / 1024).toFixed(1)}MB`);
+  console.log(`既存のサムネイル ${existingThumbs.size} 枚`);
+  console.log(`生成対象 ${targets.length} 枚${dryRun ? '（--dry-run のため生成しません）' : ''}`);
+  if (dryRun || targets.length === 0) {
+    targets.slice(0, 10).forEach((o) => console.log('  -', o.Key));
+    if (targets.length > 10) console.log(`  ... 他 ${targets.length - 10} 枚`);
+    return;
+  }
+
+  let done = 0;
+  let savedBytes = 0;
+  for (const obj of targets) {
+    const name = obj.Key.slice(PREFIX.length);
+    const thumbKey = THUMB_PREFIX + name.replace(/\.(png|jpe?g)$/i, '.webp');
+    try {
+      // R2 の公開 URL から取る。S3 の GetObject でもよいが、
+      // 公開されている状態そのものを取得できるほうが確実。
+      const res = await fetch(`${BUCKET_URL}/${obj.Key}`);
+      if (!res.ok) throw new Error(`取得に失敗: HTTP ${res.status}`);
+      const input = Buffer.from(await res.arrayBuffer());
+
+      const output = await sharp(input)
+        .resize({ width: THUMB_WIDTH, withoutEnlargement: true })
+        .webp({ quality: 80 })
+        .toBuffer();
+
+      await s3.send(
+        new PutObjectCommand({
+          Bucket: BUCKET,
+          Key: thumbKey,
+          Body: output,
+          ContentType: 'image/webp',
+          CacheControl: 'public, max-age=31536000, immutable',
+        })
+      );
+
+      done++;
+      savedBytes += input.length - output.length;
+      console.log(
+        `[${done}/${targets.length}] ${name}: ${Math.round(input.length / 1024)}KB → ${Math.round(output.length / 1024)}KB`
+      );
+    } catch (e) {
+      console.error(`  失敗: ${name} — ${e.message}`);
+    }
+  }
+
+  console.log(`\n完了: ${done}/${targets.length} 枚`);
+  console.log(`カード1枚あたりの削減: 平均 ${done ? Math.round(savedBytes / done / 1024) : 0}KB`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/generate-eyecatch.mjs
+++ b/scripts/generate-eyecatch.mjs
@@ -110,6 +110,22 @@ async function uploadToR2(buffer, filename) {
     ContentType: 'image/webp',
   }));
   console.log(`  Converted: PNG ${(buffer.length / 1024).toFixed(0)}KB → WebP ${(webpBuffer.length / 1024).toFixed(0)}KB`);
+
+  // 一覧カード用のサムネイルも同時に作る。ここで作り忘れると、カード側
+  // （src/lib/eyecatch.ts の thumbnailUrl）が 404 の URL を指すことになる。
+  const thumbBuffer = await sharp(webpBuffer)
+    .resize({ width: 320, withoutEnlargement: true })
+    .webp({ quality: 80 })
+    .toBuffer();
+  await s3.send(new PutObjectCommand({
+    Bucket: BUCKET_NAME,
+    Key: `images/eyecatch/thumb/${webpFilename}`,
+    Body: thumbBuffer,
+    ContentType: 'image/webp',
+    CacheControl: 'public, max-age=31536000, immutable',
+  }));
+  console.log(`  Thumbnail: ${(thumbBuffer.length / 1024).toFixed(0)}KB (320px)`);
+
   return `${BUCKET_URL}/${key}`;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -123,7 +123,7 @@ export default async function StaticPage() {
 
             {/* サブ記事2件（右縦並び） */}
             <div className='flex flex-col gap-4 lg:h-full'>
-              {latestBlogs.slice(1, 3).map((blog) => (
+              {latestBlogs.slice(1, 3).map((blog, index) => (
                 <Link key={blog.id} href={`/blogs/${blog.id}`} className='group block flex-1'>
                   <div className='relative h-full aspect-[16/9] lg:aspect-auto lg:min-h-0 rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-800'>
                     <Image
@@ -131,6 +131,8 @@ export default async function StaticPage() {
                       alt=''
                       fill
                       sizes='(max-width: 1024px) 100vw, 600px'
+                      // モバイルではフィーチャーの直下に積まれてファーストビューに入る
+                      priority={index === 0}
                       className='object-cover group-hover:scale-105 transition-transform duration-500'
                     />
                     <div className='absolute inset-0 bg-gradient-to-t from-black/90 via-black/40 to-black/10' />

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -41,7 +41,7 @@ export const HeroSection = () => {
             </Link>
             <Link
               href='/about'
-              className='text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors'
+              className='text-sm text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 transition-colors'
             >
               About →
             </Link>

--- a/src/components/Index/Index.tsx
+++ b/src/components/Index/Index.tsx
@@ -14,11 +14,21 @@ export const Index = ({ contents }: BlogProps) => {
   return (
     <div>
       <div className='space-y-4'>
-        {contents.map((blog) => (
-          <FadeIn key={blog.id}>
-            <PostCard blog={blog} />
-          </FadeIn>
-        ))}
+        {/*
+          先頭2件はファーストビューに入るので、遅延読み込みもフェードインもしない。
+          FadeIn は opacity-0 から始まるため、包んだままだと中の画像が LCP 候補から
+          外れ、IntersectionObserver が発火するまで «何も描かれていない» 扱いになる。
+          画像の priority と合わせて、ここだけ素通しにしている。
+        */}
+        {contents.map((blog, index) =>
+          index < 2 ? (
+            <PostCard key={blog.id} blog={blog} priority />
+          ) : (
+            <FadeIn key={blog.id}>
+              <PostCard blog={blog} />
+            </FadeIn>
+          )
+        )}
       </div>
 
       {contents.length === 0 && (

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -5,6 +5,7 @@ import { Library } from 'lucide-react';
 import type { Blog } from '../../../libs/notion';
 import { TagChip } from '../Chip/Chip';
 import { getArticleBadge } from '@/lib/articleStatus';
+import { thumbnailUrl } from '@/lib/eyecatch';
 
 /**
  * 記事一覧のカード。
@@ -53,9 +54,15 @@ type Props = {
   terms?: string[];
   /** カードの下に添える補足（検索結果の一致箇所など） */
   footer?: React.ReactNode;
+  /**
+   * ファーストビューに入るカードだけ true にする。
+   * 既定の遅延読み込みのままだと、一覧ページで LCP になるこの画像の
+   * リクエスト開始が 5.5 秒遅れていた（Lighthouse の Load Delay が LCP の53%）。
+   */
+  priority?: boolean;
 };
 
-export const PostCard = ({ blog, terms, footer }: Props) => {
+export const PostCard = ({ blog, terms, footer, priority = false }: Props) => {
   const badge = getArticleBadge(blog);
 
   return (
@@ -66,19 +73,21 @@ export const PostCard = ({ blog, terms, footer }: Props) => {
         <div className='flex gap-4 p-4 rounded-xl bg-white dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 shadow-sm hover:shadow-lg hover:border-slate-200 dark:hover:border-slate-600 hover:-translate-y-0.5 transition-all duration-300'>
           <div className='flex-shrink-0 relative w-24 sm:w-32 aspect-[4/3] rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-700'>
             <Image
-              src={blog.eyecatch?.url || '/images/no_image_generated.png'}
+              src={thumbnailUrl(blog.eyecatch?.url) || '/images/no_image_generated.png'}
               alt=''
               fill
               // 実表示は96〜128px。sizes がないと 100vw 扱いになり原寸が配信される
               sizes='(max-width: 640px) 96px, 128px'
+              priority={priority}
               className='object-cover group-hover:scale-105 transition-transform duration-300'
             />
+            {/* 白文字を載せるので 500 番だとコントラスト比が 3.7 前後で 4.5 に届かない */}
             {badge === 'new' ? (
-              <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-red-500 text-white rounded'>
+              <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-red-600 text-white rounded'>
                 NEW
               </span>
             ) : badge === 'updated' ? (
-              <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-blue-500 text-white rounded'>
+              <span className='absolute top-1.5 left-1.5 px-1.5 py-0.5 text-[10px] font-bold bg-blue-600 text-white rounded'>
                 更新
               </span>
             ) : null}
@@ -92,7 +101,7 @@ export const PostCard = ({ blog, terms, footer }: Props) => {
                 <Library className='h-3 w-3 shrink-0' aria-hidden='true' />
                 <span className='truncate'>{blog.series.name}</span>
                 {blog.series.order > 0 && (
-                  <span className='shrink-0 tabular-nums text-slate-400 dark:text-slate-500'>
+                  <span className='shrink-0 tabular-nums text-slate-600 dark:text-slate-400'>
                     #{blog.series.order}
                   </span>
                 )}
@@ -105,12 +114,12 @@ export const PostCard = ({ blog, terms, footer }: Props) => {
 
             {/* 抜粋。タイトルだけでは中身が判断できず、一覧で開くかどうかを決められなかった */}
             {blog.ogpDescription && (
-              <p className='text-xs text-slate-500 dark:text-slate-400 line-clamp-2 leading-relaxed'>
+              <p className='text-xs text-slate-600 dark:text-slate-300 line-clamp-2 leading-relaxed'>
                 <HighlightText text={blog.ogpDescription} terms={terms} />
               </p>
             )}
 
-            <div className='flex items-center gap-1.5 text-[11px] text-slate-500 dark:text-slate-400'>
+            <div className='flex items-center gap-1.5 text-[11px] text-slate-600 dark:text-slate-400'>
               {/* 相対表記だと「いつの記事か」が直感的に分かる。技術記事は鮮度が重要 */}
               <time
                 className='whitespace-nowrap'
@@ -138,7 +147,7 @@ export const PostCard = ({ blog, terms, footer }: Props) => {
                   <TagChip key={tag.id} name={tag.name} />
                 ))}
                 {blog.tags.length > 3 && (
-                  <span className='self-center text-[11px] text-slate-500 dark:text-slate-400'>
+                  <span className='self-center text-[11px] text-slate-600 dark:text-slate-400'>
                     +{blog.tags.length - 3}
                   </span>
                 )}

--- a/src/lib/eyecatch.ts
+++ b/src/lib/eyecatch.ts
@@ -1,0 +1,30 @@
+/**
+ * アイキャッチ画像の URL 変換。
+ *
+ * Cloudflare Pages では Next.js の画像最適化が動かないので
+ * （next.config.js の `images.unoptimized: true`）、R2 に置いた原寸が
+ * そのまま配信される。記事ページのヒーローには 1376px 幅が要るが、
+ * 一覧カードでの表示は 96〜128px しかなく、1枚あたり 50KB 前後を捨てていた。
+ *
+ * そこで `scripts/generate-eyecatch-thumbnails.mjs` で幅 320px の版を
+ * `images/eyecatch/thumb/` に用意し、カードだけそちらを見る。
+ */
+
+/** R2 のアイキャッチ置き場。ここに一致する URL だけ差し替える */
+const EYECATCH_PATH = '/images/eyecatch/';
+const THUMB_PATH = '/images/eyecatch/thumb/';
+
+/**
+ * 一覧カード用のサムネイル URL を返す。
+ *
+ * R2 のアイキャッチ以外（ローカルのフォールバック画像や Notion の画像）は
+ * サムネイルを持たないので、渡された URL をそのまま返す。
+ */
+export function thumbnailUrl(url: string | undefined | null): string | undefined {
+  if (!url) return undefined;
+  if (!url.includes(EYECATCH_PATH)) return url;
+  // すでにサムネイルなら二重変換しない
+  if (url.includes(THUMB_PATH)) return url;
+  // 生成側は拡張子を .webp に揃えている
+  return url.replace(EYECATCH_PATH, THUMB_PATH).replace(/\.(png|jpe?g)$/i, '.webp');
+}


### PR DESCRIPTION
## なぜ

記事詳細ページの太字が「強調」ではなく「黒い帯」に見えていた。

日本語のゴシック体は 400 と 700 の面積差が欧文よりずっと大きい。そこに本文が `--foreground`（ほぼ純黒 `#0f1729`）のままだったため、太字にすると逃げ場がなく、段落の中に真っ黒な塊ができて流れが切れていた。

あわせて、フォントのウェイト階層が実質2段しかないことも分かった。`styles/noto-sans-jp.css` が読み込んでいるのは **400 / 500 / 700 の3ウェイト**のみ。ブラウザで同じ文字列の描画幅を測ると:

```
400: 662.72px   500: 668.23px
600: 675.36px   700: 675.36px   800: 675.36px   900: 675.36px
```

600以上はすべて 700 のフェイスで描かれている。つまり `.znc h2 { font-weight: 800 }` は効いておらず、h3 と同じ太さだった。使える段は 400・500・700 の3つだけ。

## なにを

- **本文を一段落として、見出しと太字だけを濃く置く。** 強調をウェイトではなく濃さの差で作る
  - 本文 `#334155` / ダーク `#cbd5e1`
  - 見出し・太字 `#0f172a` / ダーク `#f1f5f9`
- **`strong` / `b` のウェイトを 700 → 500 に。** 500 は読み込み済みのフェイス
- `h2` の `font-weight: 800` を実態に合わせて 700 に（見た目は変わらない。CSSの嘘を消すだけ）
- 本文が薄くなったぶん、**ダークの引用と脚注を一段落として**階層を保つ（どちらも `#cbd5e1` で、新しい本文色と同色になってしまうため）
- 本文色は `.znc` が持つようにし、詳細度が同じで読み込み順に依存していた `text-foreground` を外す

表・インラインコード・コードブロックも本文の濃さに揃えた（`th` は見出し行なので濃い側）。

## 確認

ローカル (`next dev`) でライト / ダーク両方を確認。本文・見出し・太字・引用・表・インラインコード・コードブロックの見え方に崩れなし。

補足: `strong` に 500 を使うことで、日本語サブセットの Medium が本文で初めて必要になるため、フォントの追加フェッチが1〜数ファイル発生する（`unicode-range` で分割済みなので、実際に使う範囲のみ）。

## スコープ外（別途）

- 記事詳細ページで既存の Hydration mismatch が出ている（`ShareButtons` が `navigator.share` の有無でサーバーとクライアントの出し分けをしている）。今回の変更とは無関係
- 欧文を別フォントにする和欧混植は入れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVggujNbpUzmTt46wV3NYG