### PR TITLE
一覧カードのサムネイルが記事ごとに縦長になるのを直す

### DIFF
--- a/src/app/archives/[archive]/loading.tsx
+++ b/src/app/archives/[archive]/loading.tsx
@@ -12,8 +12,10 @@ export default function Loading() {
           </div>
           <div className='space-y-4'>
             {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div key={i} className='flex gap-5 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
-                <div className='flex-shrink-0 w-28 sm:w-36 aspect-[1200/630] rounded-lg bg-slate-200 dark:bg-slate-700'></div>
+              <div key={i} className='flex gap-4 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
+                {/* 実物の PostCard と同じ寸法にする。以前は幅も比率も違ったため、
+                    読み込み完了の瞬間にサムネイルの大きさが変わっていた */}
+                <div className='flex-shrink-0 self-start w-24 sm:w-32 aspect-square rounded-lg bg-slate-200 dark:bg-slate-700'></div>
                 <div className='flex-1 flex flex-col justify-center gap-2.5'>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[85%]'></div>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[60%]'></div>

--- a/src/app/blogs/page/[pageId]/loading.tsx
+++ b/src/app/blogs/page/[pageId]/loading.tsx
@@ -12,8 +12,10 @@ export default function Loading() {
           </div>
           <div className='space-y-4'>
             {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div key={i} className='flex gap-5 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
-                <div className='flex-shrink-0 w-28 sm:w-36 aspect-[1200/630] rounded-lg bg-slate-200 dark:bg-slate-700'></div>
+              <div key={i} className='flex gap-4 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
+                {/* 実物の PostCard と同じ寸法にする。以前は幅も比率も違ったため、
+                    読み込み完了の瞬間にサムネイルの大きさが変わっていた */}
+                <div className='flex-shrink-0 self-start w-24 sm:w-32 aspect-square rounded-lg bg-slate-200 dark:bg-slate-700'></div>
                 <div className='flex-1 flex flex-col justify-center gap-2.5'>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[85%]'></div>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[60%]'></div>

--- a/src/app/categories/[categoryId]/loading.tsx
+++ b/src/app/categories/[categoryId]/loading.tsx
@@ -12,8 +12,10 @@ export default function Loading() {
           </div>
           <div className='space-y-4'>
             {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div key={i} className='flex gap-5 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
-                <div className='flex-shrink-0 w-28 sm:w-36 aspect-[1200/630] rounded-lg bg-slate-200 dark:bg-slate-700'></div>
+              <div key={i} className='flex gap-4 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
+                {/* 実物の PostCard と同じ寸法にする。以前は幅も比率も違ったため、
+                    読み込み完了の瞬間にサムネイルの大きさが変わっていた */}
+                <div className='flex-shrink-0 self-start w-24 sm:w-32 aspect-square rounded-lg bg-slate-200 dark:bg-slate-700'></div>
                 <div className='flex-1 flex flex-col justify-center gap-2.5'>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[85%]'></div>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[60%]'></div>

--- a/src/app/categories/[categoryId]/page/[pageId]/loading.tsx
+++ b/src/app/categories/[categoryId]/page/[pageId]/loading.tsx
@@ -12,8 +12,10 @@ export default function Loading() {
           </div>
           <div className='space-y-4'>
             {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div key={i} className='flex gap-5 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
-                <div className='flex-shrink-0 w-28 sm:w-36 aspect-[1200/630] rounded-lg bg-slate-200 dark:bg-slate-700'></div>
+              <div key={i} className='flex gap-4 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
+                {/* 実物の PostCard と同じ寸法にする。以前は幅も比率も違ったため、
+                    読み込み完了の瞬間にサムネイルの大きさが変わっていた */}
+                <div className='flex-shrink-0 self-start w-24 sm:w-32 aspect-square rounded-lg bg-slate-200 dark:bg-slate-700'></div>
                 <div className='flex-1 flex flex-col justify-center gap-2.5'>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[85%]'></div>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[60%]'></div>

--- a/src/app/searches/loading.tsx
+++ b/src/app/searches/loading.tsx
@@ -12,8 +12,10 @@ export default function Loading() {
           </div>
           <div className='space-y-4'>
             {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div key={i} className='flex gap-5 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
-                <div className='flex-shrink-0 w-28 sm:w-36 aspect-[1200/630] rounded-lg bg-slate-200 dark:bg-slate-700'></div>
+              <div key={i} className='flex gap-4 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
+                {/* 実物の PostCard と同じ寸法にする。以前は幅も比率も違ったため、
+                    読み込み完了の瞬間にサムネイルの大きさが変わっていた */}
+                <div className='flex-shrink-0 self-start w-24 sm:w-32 aspect-square rounded-lg bg-slate-200 dark:bg-slate-700'></div>
                 <div className='flex-1 flex flex-col justify-center gap-2.5'>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[85%]'></div>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[60%]'></div>

--- a/src/app/tags/[tagId]/loading.tsx
+++ b/src/app/tags/[tagId]/loading.tsx
@@ -12,8 +12,10 @@ export default function Loading() {
           </div>
           <div className='space-y-4'>
             {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div key={i} className='flex gap-5 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
-                <div className='flex-shrink-0 w-28 sm:w-36 aspect-[1200/630] rounded-lg bg-slate-200 dark:bg-slate-700'></div>
+              <div key={i} className='flex gap-4 p-4 rounded-xl border border-slate-100 dark:border-slate-700/50'>
+                {/* 実物の PostCard と同じ寸法にする。以前は幅も比率も違ったため、
+                    読み込み完了の瞬間にサムネイルの大きさが変わっていた */}
+                <div className='flex-shrink-0 self-start w-24 sm:w-32 aspect-square rounded-lg bg-slate-200 dark:bg-slate-700'></div>
                 <div className='flex-1 flex flex-col justify-center gap-2.5'>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[85%]'></div>
                   <div className='h-5 bg-slate-200 dark:bg-slate-700 rounded w-[60%]'></div>

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -71,7 +71,13 @@ export const PostCard = ({ blog, terms, footer, priority = false }: Props) => {
         {/* 固定高をやめ、内容に応じて伸びるようにした。
             短いタイトルでは余白が間延びし、長いタイトルは切れていた。 */}
         <div className='flex gap-4 p-4 rounded-xl bg-white dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 shadow-sm hover:shadow-lg hover:border-slate-200 dark:hover:border-slate-600 hover:-translate-y-0.5 transition-all duration-300'>
-          <div className='flex-shrink-0 relative w-24 sm:w-32 aspect-[4/3] rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-700'>
+          {/* self-start が要る。flex の既定 align-items: stretch は高さ auto の子を
+              親いっぱいに伸ばし、そこで height が確定するため aspect-ratio は無視される。
+              以前は aspect-[4/3] と書いてあるのに、カードの中身（タイトルの行数・抜粋・
+              タグの数）に引きずられて画像が縦に伸び、記事ごとに 120px〜165px とバラついていた。
+              比率は正方形。アイキャッチ(1200x630)の左右は切れるが、カードの高さとほぼ揃うので
+              画像の下に余白が出ない。 */}
+          <div className='flex-shrink-0 self-start relative w-24 sm:w-32 aspect-square rounded-lg overflow-hidden bg-slate-100 dark:bg-slate-700'>
             <Image
               src={thumbnailUrl(blog.eyecatch?.url) || '/images/no_image_generated.png'}
               alt=''


### PR DESCRIPTION
## なぜ

一覧カードのサムネイルが記事によって縦長になり、大きさもバラバラだった（PC・SP どちらでも）。

`aspect-[4/3]` は指定してあるのに効いていない。原因は **flex の既定 `align-items: stretch` が `aspect-ratio` を上書きしていた**こと。高さ auto の flex アイテムは親いっぱいに伸ばされ、その時点で height が確定するため、`aspect-ratio` は無視される。結果、画像の高さがカードの中身（タイトルの行数・抜粋・タグの数）に引きずられていた。

実測（本番、PC 1470px）:

| ページ | 実サイズ | 比率 | 期待 |
|---|---|---|---|
| 一覧 | 128×144 / 128×165 | 0.89 / 0.78 | 1.33 |
| TOP | 128×120 / 128×121 | 1.07 / 1.06 | 1.33 |

## なにを

- **`PostCard` の画像コンテナに `self-start` を足して stretch を外す**。これで `aspect-ratio` が効く
- **比率は正方形（`aspect-square`）**。カードの高さとほぼ揃うので画像の下に余白が出ない。アイキャッチ (1200×630) の左右は切れるが、`object-cover` なので歪みはない
- **一覧系のスケルトン6つも実物と同じ寸法に揃えた**（`w-24 sm:w-32` / `aspect-square` / `gap-4`）。以前は `w-28 sm:w-36` / `aspect-[1200/630]` で幅も比率も違い、読み込みが終わった瞬間にサムネイルの大きさが変わっていた

## 確認

ローカル (`next dev`) で実測:

- PC 1440px: 全カード **128×128**（比 1.00）
- SP 390px: 全カード **96×96**（比 1.00）

記事によるバラつきは無くなりました。

## スコープ外

TOP の大きいフィーチャー画像（左 552×420、右 552×202）は左右で比率が違いますが、これは左の大カードと右の小カード2つで高さを揃えるための意図的なレイアウト（`lg:aspect-auto lg:h-full`）なので、今回は触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVggujNbpUzmTt46wV3NYG