### PR TITLE
perf: 画像の配信を R2 のカスタムドメインに寄せる

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,8 @@ const nextConfig = {
     remotePatterns: [
       { protocol: 'https', hostname: 'images.microcms-assets.io' },
       { protocol: 'https', hostname: 'images.unsplash.com' },
+      { protocol: 'https', hostname: 'img.kt-tech.blog' },
+      // 旧配信元。Notion に保存済みの URL がそのまま渡ることがあるので残す
       { protocol: 'https', hostname: 'pub-9d03846db4364486bb0806774184931a.r2.dev' },
       { protocol: 'https', hostname: 'www.notion.so' },
       { protocol: 'https', hostname: 'prod-files-secure.s3.us-west-2.amazonaws.com' },
@@ -79,7 +81,7 @@ const nextConfig = {
               "style-src 'self' 'unsafe-inline'",
               "font-src 'self' data:",
               // R2 のアイキャッチ / Notion の署名付き画像 / favicon / YouTube のサムネイル
-              "img-src 'self' data: blob: https://pub-9d03846db4364486bb0806774184931a.r2.dev https://prod-files-secure.s3.us-west-2.amazonaws.com https://www.notion.so https://i.ytimg.com https://www.google.com https://*.googlesyndication.com https://*.google-analytics.com",
+              "img-src 'self' data: blob: https://img.kt-tech.blog https://pub-9d03846db4364486bb0806774184931a.r2.dev https://prod-files-secure.s3.us-west-2.amazonaws.com https://www.notion.so https://i.ytimg.com https://www.google.com https://*.googlesyndication.com https://*.google-analytics.com",
               "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
               // 記事内の埋め込み
               "frame-src https://www.youtube-nocookie.com https://codesandbox.io https://stackblitz.com https://speakerdeck.com https://www.figma.com https://www.google.com https://*.googlesyndication.com",

--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -62,6 +62,7 @@ import { SeriesNav } from '@/components/Series/SeriesNav';
 import { SeriesCarousel } from '@/components/Series/SeriesCarousel';
 import { ArticleAside } from '@/components/ArticleAside/ArticleAside';
 import { ArticleSummary } from '@/components/ArticleSummary/ArticleSummary';
+import { toCustomHost } from '@/lib/eyecatch';
 import { ArticleChangelog } from '@/components/ArticleSummary/ArticleChangelog';
 import { findSeriesOf } from '@/lib/series';
 import { isPublic } from '@/lib/blog';
@@ -102,7 +103,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     blog.ogpDescription ||
     (blog.summary?.length ? blog.summary.join('、').slice(0, 120) : '') ||
     text.slice(0, 120).replace(/\n/g, ' ').trim();
-  const ogImage = blog.eyecatch?.url;
+  const ogImage = toCustomHost(blog.eyecatch?.url);
   const pageUrl = `${process.env.SITE_URL}/blogs/${blogId}`;
 
   // 検索結果のタイトルは日本語で30文字ほどで切られる。そこに
@@ -374,7 +375,7 @@ export default async function StaticDetailPage({
     // レンダリング後のHTMLから起こした平文を使えば、記法は残らない。
     description: (blog.ogpDescription || plainText).replace(/\s+/g, ' ').slice(0, 160).trim(),
     ...(blog.summary?.length ? { abstract: blog.summary.join(' / ') } : {}),
-    image: blog.eyecatch?.url || `${process.env.SITE_URL}/opengraph-image`,
+    image: toCustomHost(blog.eyecatch?.url) || `${process.env.SITE_URL}/opengraph-image`,
     datePublished: new Date(blog.publishedAt).toISOString(),
     dateModified: new Date(blog.updatedAt).toISOString(),
     inLanguage: 'ja',
@@ -398,7 +399,7 @@ export default async function StaticDetailPage({
     },
     keywords: blog.tags?.map(t => t.name).join(', '),
     articleSection: blog.category?.name,
-    thumbnailUrl: blog.eyecatch?.url,
+    thumbnailUrl: toCustomHost(blog.eyecatch?.url),
     speakable: {
       '@type': 'SpeakableSpecification',
       cssSelector: ['[data-article-title]', '[data-article-description]'],
@@ -493,7 +494,7 @@ export default async function StaticDetailPage({
               {/* アイキャッチは自動生成の抽象画像で内容を説明しないため、
                   高さを抑えて本文までの距離を縮める */}
               <Image
-                src={blog.eyecatch?.url || '/images/no_image_generated.png'}
+                src={toCustomHost(blog.eyecatch?.url) || '/images/no_image_generated.png'}
                 alt=''
                 width={1200}
                 height={630}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -143,8 +143,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           type='application/ld+json'
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        <link rel='dns-prefetch' href='https://pub-9d03846db4364486bb0806774184931a.r2.dev' />
-        <link rel='preconnect' href='https://pub-9d03846db4364486bb0806774184931a.r2.dev' crossOrigin='anonymous' />
+        <link rel='dns-prefetch' href='https://img.kt-tech.blog' />
+        <link rel='preconnect' href='https://img.kt-tech.blog' crossOrigin='anonymous' />
         <link rel='dns-prefetch' href='https://www.googletagmanager.com' />
         <link rel='dns-prefetch' href='https://www.google.com' />
         {/* JS無効時、スクロール連動で表示する要素が非表示のままにならないようにする */}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -7,7 +7,7 @@ export const contentType = 'image/png';
 
 export default async function Image() {
   // 幾何学的背景画像をR2から取得してbase64化
-  const bgUrl = 'https://pub-9d03846db4364486bb0806774184931a.r2.dev/images/site-ogp.png';
+  const bgUrl = 'https://img.kt-tech.blog/images/site-ogp.png';
 
   return new ImageResponse(
     (

--- a/src/lib/eyecatch.ts
+++ b/src/lib/eyecatch.ts
@@ -8,21 +8,43 @@
  *
  * `scripts/generate-eyecatch-thumbnails.mjs` が幅ごとの版を作って
  * `images/eyecatch/<variant>/` に置くので、用途に合わせてそれを見る。
+ *
+ * あわせて配信ホストも差し替える。Notion に保存されている URL は R2 の
+ * パブリック開発 URL（pub-*.r2.dev）だが、これは HTTP/1.1 でしか話せず
+ * Cloudflare のキャッシュも効かない（Cloudflare 自身が本番非推奨としている）。
+ * バケットに繋いだカスタムドメインなら HTTP/2 かつキャッシュが効く。
  */
 
 /** R2 のアイキャッチ置き場。ここに一致する URL だけ差し替える */
 const EYECATCH_PATH = '/images/eyecatch/';
 
+/** Notion に保存されている配信元。レート制限があり本番向けではない */
+const R2_PUBLIC_HOST = 'pub-9d03846db4364486bb0806774184931a.r2.dev';
+/** バケットに繋いだカスタムドメイン。HTTP/2 + Cloudflare のキャッシュが効く */
+const R2_CUSTOM_HOST = 'img.kt-tech.blog';
+
 /** 生成スクリプトの VARIANTS と名前を合わせること */
 type Variant = 'thumb' | 'medium';
 
+/**
+ * R2 の配信ホストをカスタムドメインへ寄せる。
+ * R2 以外（Notion の画像やローカルのフォールバック）はそのまま返す。
+ */
+export function toCustomHost(url: string | undefined | null): string | undefined {
+  if (!url) return undefined;
+  return url.replace(`https://${R2_PUBLIC_HOST}`, `https://${R2_CUSTOM_HOST}`);
+}
+
 function variantUrl(url: string | undefined | null, variant: Variant): string | undefined {
   if (!url) return undefined;
-  if (!url.includes(EYECATCH_PATH)) return url;
+  if (!url.includes(EYECATCH_PATH)) return toCustomHost(url);
   // すでに派生版を指しているなら二重変換しない
-  if (/\/images\/eyecatch\/(thumb|medium)\//.test(url)) return url;
+  if (/\/images\/eyecatch\/(thumb|medium)\//.test(url)) return toCustomHost(url);
   // 生成側は拡張子を .webp に揃えている
-  return url.replace(EYECATCH_PATH, `${EYECATCH_PATH}${variant}/`).replace(/\.(png|jpe?g)$/i, '.webp');
+  const resized = url
+    .replace(EYECATCH_PATH, `${EYECATCH_PATH}${variant}/`)
+    .replace(/\.(png|jpe?g)$/i, '.webp');
+  return toCustomHost(resized);
 }
 
 /** 一覧カード用（幅 320px）。表示は 96〜128px */


### PR DESCRIPTION
Notion に保存されているアイキャッチのURLは R2 の**パブリック開発URL**（`pub-*.r2.dev`）で、これは HTTP/1.1 でしか話せず Cloudflare のキャッシュも効きません。Cloudflare 自身がダッシュボードで「レート制限があり本番環境での使用は推奨されません」と表示しているものでした。Lighthouse の「Use HTTP/2: 390ms」がこれを指しています。

## やったこと

バケット `microcms-image` に **`img.kt-tech.blog`** を接続しました（追加されたDNSは CNAME 1本のみ）。

接続後の実測です。

```
before: HTTP/1.1 / cf-cache-status なし
after : HTTP/2   / cf-cache-status: HIT
```

## コード側

| ファイル | 変更 |
|---|---|
| `src/lib/eyecatch.ts` | `toCustomHost()` を追加し、thumb/medium の変換と同じ経路でホストも差し替え |
| `src/app/blogs/[blogId]/page.tsx` | ヒーロー画像・OGP・構造化データの `thumbnailUrl` も同じ関数を通す |
| `src/app/layout.tsx` | `preconnect` / `dns-prefetch` を新ホストへ |
| `next.config.js` | `remotePatterns` と CSP の `img-src` に新ホストを追加（**旧ホストは残す**） |

旧ホストを残しているのは、Notion 側の値がそのまま渡る経路があるためです。

## 検証について正直に

**この変更はローカルで確認できていません。** `npm run start` がビルド成果物と食い違う出力を返す状態が続いており（今日3回目）、`.next` を消して再ビルド・再起動しても旧ホストのままでした。

バンドルされたJSには置換が正しく入っていることは確認済みです。

```js
function l(e){ if(e) return e.replace("https://pub-...r2.dev","https://img.kt-tech.blog") }
```

**マージ後に本番で実測します。** 仮に置換が効かなかった場合も旧ホストで表示されるだけで、表示が壊れることはありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt