### PR TITLE
chore: 本番と同じ状態をローカルで確認できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ yarn-error.log*
 # local env files
 .env*.local
 
+# wrangler pages dev が読む環境変数。.env.local から生成するのでコミットしない
+.dev.vars
+
 # vercel
 .vercel
 
@@ -44,3 +47,6 @@ next-env.d.ts
 # OpenNext build
 .open-next/
 .gcp-sa-key.json
+
+# wrangler / next-on-pages の作業ディレクトリ
+.wrangler

--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ npm install --legacy-peer-deps
 npm run dev
 ```
 
+### 本番と同じ状態で確認する
+
+```bash
+npm run preview   # → http://localhost:8788
+```
+
+**`npm run start` は本番の再現にならない。** `next start` は Node.js サーバーとして動くが、
+本番は Cloudflare Pages（`@cloudflare/next-on-pages` が生成する Worker）で動いており、
+CSS のバンドル結果もページごとの読み込みも別物になる。実際 `next start` では
+
+- 記事ページに layout の CSS が読み込まれず、`--font-noto-sans-jp` が未定義になる
+- ソースを変えてビルドし直しても、古い出力を返し続けることがある
+
+といった食い違いが出る。フォントや画像 URL のように「本番でどう配信されるか」が
+問われる変更は、必ず `npm run preview` で確認すること。
+
+`preview` は次の3つをまとめて実行する。
+
+| | 内容 |
+|---|---|
+| `preview:env` | `.env.local` → `.dev.vars` を同期。wrangler は `.env.local` を読まないので、無いと全ページ 503 |
+| `pages:build` | `@cloudflare/next-on-pages` で本番と同じビルド |
+| `preview:serve` | `wrangler pages dev`。`nodejs_compat` フラグが無いと Worker が起動せず 503 |
+
 ## ビルド・デプロイ
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "lint:fix": "yarn lint --fix",
     "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json}'",
     "pages:build": "npx @cloudflare/next-on-pages",
-    "pages:deploy": "npx wrangler pages deploy .vercel/output/static --project-name=kt-tech-blog"
+    "pages:deploy": "npx wrangler pages deploy .vercel/output/static --project-name=kt-tech-blog",
+    "preview": "npm run preview:env && npm run pages:build && npm run preview:serve",
+    "preview:env": "node scripts/sync-dev-vars.mjs",
+    "preview:serve": "wrangler pages dev .vercel/output/static --port 8788 --compatibility-date 2026-08-15 --compatibility-flags nodejs_compat"
   },
   "dependencies": {
     "@cloudflare/next-on-pages": "^1.13.16",

--- a/scripts/sync-dev-vars.mjs
+++ b/scripts/sync-dev-vars.mjs
@@ -1,0 +1,27 @@
+// `.env.local` から `.dev.vars` を作る。
+//
+// wrangler は `.env.local` を読まない（Next.js の作法とは別で、`.dev.vars` を見る）。
+// これが無いと `wrangler pages dev` が環境変数なしで動き、Notion API を叩けず
+// 全ページが 503 になる。原因が分かりにくいので毎回自動で同期する。
+//
+// `.dev.vars` は秘匿情報そのものなので .gitignore に入れてある。
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+const SRC = '.env.local';
+const DEST = '.dev.vars';
+
+if (!existsSync(SRC)) {
+  console.error(`${SRC} がありません。.env.example を参考に作成してください。`);
+  process.exit(1);
+}
+
+const body = readFileSync(SRC, 'utf-8');
+writeFileSync(DEST, body);
+
+const count = body
+  .split('\n')
+  .filter((line) => line.trim() && !line.trim().startsWith('#') && line.includes('='))
+  .length;
+
+console.log(`${DEST} を更新しました（${count} 変数）`);


### PR DESCRIPTION
`npm run start` は**本番の再現になっていませんでした**。`next start` は Node.js サーバーとして動きますが、本番は Cloudflare Pages（`@cloudflare/next-on-pages` が生成する Worker）で、CSSのバンドル結果もページごとの読み込みも別物になります。

実際に踏んだ症状です。

- 記事ページに layout の CSS が読み込まれず、`--font-noto-sans-jp` が**未定義**になる
- ソースを変えてビルドし直しても、**古い出力を返し続ける**（今日3回遭遇）

このためフォントの変更を検証できず、誤った判断のまま本番に出して**記事本文の太字を壊しました**（#530）。同じことを繰り返さないための土台です。

## 使い方

```bash
npm run preview   # → http://localhost:8788
```

内部では3つを順に実行します。

| | 内容 | これが無いと |
|---|---|---|
| `preview:env` | `.env.local` → `.dev.vars` を同期 | wrangler は `.env.local` を読まないので、Notion API を叩けず**全ページ 503** |
| `pages:build` | `@cloudflare/next-on-pages` で本番と同じビルド | — |
| `preview:serve` | `wrangler pages dev` | `nodejs_compat` フラグが無いと Worker が起動せず **503** |

どちらも今日実際に踏んで、原因が分かりにくかったので自動化しました。

## 検証：本番と一致することを確認

`next start` では再現できなかった項目が、すべて本番と一致しました。

| 項目 | `npm run start` | `npm run preview` |
|---|---|---|
| 記事ページの `@font-face` | **0個** | **125個**（`100 900` が124件） |
| CSSファイル名 | 別物 | `0182eebeb34a8720.css`（**本番と同一ハッシュ**） |
| `--font-noto-sans-jp` | **未定義** | 定義あり |
| 画像ホスト | **旧 `pub-*.r2.dev`** | `img.kt-tech.blog` |

ブラウザでの実測でも、可変フォントが効いていることを確認しています。

```
400 = 1601.88 / 500 = 1616.81 / 700 = 1636.14
フォールバック参照値 = 1675.87   ← どれとも一致しない
```

## 補足

`.dev.vars`（秘匿情報そのもの）と `.wrangler`（作業ディレクトリ）は `.gitignore` に追加済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt