### PR TITLE
seo: 記事ページの title からサイト名のサフィックスを外す

### DIFF
--- a/src/app/blogs/[blogId]/page.tsx
+++ b/src/app/blogs/[blogId]/page.tsx
@@ -126,7 +126,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       : blog.title;
 
   return {
-    title: metaTitle,
+    // absolute にしてサイト名のサフィックス（" | kt-tech.blog" = 15字）を付けない。
+    // 検索結果に出るのは日本語で全角30字前後までで、記事タイトルは中央値59字あり、
+    // 89本中40本が60字を超えて途中で切れていた。外すと 40本 → 11本になる。
+    // サイト名は WebSite / Organization の構造化データで別途伝えているので、
+    // タイトル側で重ねて名乗る必要はない。
+    title: { absolute: metaTitle },
     description,
     alternates: {
       canonical: pageUrl,


### PR DESCRIPTION
公開中の89記事の `<title>` を数えたところ、**中央値59字**で、**40本が60字を超えて検索結果で途中が切れていました**。

検索結果に表示されるタイトルは日本語で**全角30字前後**までです。

```
【設計】Claude Code のセッション同士を会話させる — SendMessage と、権限が越境しない設計 | kt-tech.blog
                                     ↑ このあたりで切れる
```

内訳を見ると `" | kt-tech.blog"` のサフィックスが**15字**を占めていました。

## 効果（実測）

記事ページだけ `absolute` にして外した場合の試算です。

| | 現在 | 除去後 |
|---|---|---|
| 60字超の記事 | **40件** | **11件** |
| 40字超の記事 | 81件 | 53件 |
| タイトル長の中央値 | 59字 | **44字** |

サイト名は `WebSite` / `Organization` の構造化データで別途伝えているので、タイトル側で重ねて名乗る必要はありません。

## 変更範囲

**記事ページのみ**です。テンプレート自体は変えていないので、タイトルが短いページはサフィックスが残ります。

`npm run preview`（本番と同じ Cloudflare Pages ビルド）で確認しました。

```
記事    → Claude Code のセッション同士を会話させる — SendMessage と、権限が越境しない設計
/about  → About | kt-tech.blog
一覧    → ブログ記事一覧 | kt-tech.blog
```

## 残る課題

外してもなお40字を超える記事が**53本**あります。これはタイトル自体の長さで、記事ごとの判断が要るため本PRでは触っていません。最長はこれです。

```
93字  Claude Code の "Browser extension is not connected" を最後まで追う
      — ネイティブメッセージングと Unix ソケットで真因を確定させる
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4wLkfMfy6gRpwqD8Yq5Vt